### PR TITLE
fix: Parsing of VersionExchangeMessage without CR

### DIFF
--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/message/VersionExchangeMessage.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/message/VersionExchangeMessage.java
@@ -18,6 +18,7 @@ public class VersionExchangeMessage extends ProtocolMessage<VersionExchangeMessa
 
     private ModifiableString version;
     private ModifiableString comment;
+    private ModifiableString endOfMessageSequence;
 
     public VersionExchangeMessage() {
         super();
@@ -52,6 +53,20 @@ public class VersionExchangeMessage extends ProtocolMessage<VersionExchangeMessa
         return this.version.getValue()
                 + CharConstants.VERSION_COMMENT_SEPARATOR
                 + this.comment.getValue();
+    }
+
+    public ModifiableString getEndOfMessageSequence() {
+        return endOfMessageSequence;
+    }
+
+    public void setEndOfMessageSequence(ModifiableString endOfMessageSequence) {
+        this.endOfMessageSequence = endOfMessageSequence;
+    }
+
+    public void setEndOfMessageSequence(String endOfMessageSequence) {
+        this.endOfMessageSequence =
+                ModifiableVariableFactory.safelySetValue(
+                        this.endOfMessageSequence, endOfMessageSequence);
     }
 
     @Override

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/parser/VersionExchangeMessageParser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/parser/VersionExchangeMessageParser.java
@@ -28,10 +28,14 @@ public class VersionExchangeMessageParser extends ProtocolMessageParser<VersionE
 
     private void parseVersion() {
         // parse till CR NL (and remove them)
-        String result =
-                this.parseStringTill(new byte[] {CharConstants.NEWLINE})
-                        .replace("\r", "")
-                        .replace("\n", "");
+        String result = this.parseStringTill(new byte[] {CharConstants.NEWLINE});
+        if (result.contains("\r")) {
+            message.setEndOfMessageSequence("\r\n");
+        } else {
+            message.setEndOfMessageSequence("\n");
+        }
+        result = result.replace("\n", "").replace("\r", "");
+
         String[] parts = result.split(String.valueOf(CharConstants.VERSION_COMMENT_SEPARATOR), 2);
         message.setVersion(parts[0]);
         LOGGER.debug("Version: " + parts[0]);

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/VersionExchangeMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/VersionExchangeMessagePreparator.java
@@ -23,10 +23,14 @@ public class VersionExchangeMessagePreparator
         if (context.isClient()) {
             getObject().setVersion(context.getChooser().getClientVersion());
             getObject().setComment(context.getChooser().getClientComment());
+            // TODO: Use chooser here
+            getObject().setEndOfMessageSequence("\r\n");
             context.getExchangeHashInstance().setClientVersion(getObject());
         } else {
             getObject().setVersion(context.getChooser().getServerVersion());
             getObject().setComment(context.getChooser().getServerComment());
+            // TODO: Use chooser here
+            getObject().setEndOfMessageSequence("\r\n");
             context.getExchangeHashInstance().setServerVersion(getObject());
         }
     }

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/VersionExchangeMessageSerializer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/VersionExchangeMessageSerializer.java
@@ -44,14 +44,20 @@ public class VersionExchangeMessageSerializer
         }
     }
 
-    private void serializeCRNL() {
-        appendBytes(new byte[] {CharConstants.CARRIAGE_RETURN, CharConstants.NEWLINE});
+    private void serializeEndOfMessageSequence() {
+        LOGGER.debug(
+                "End of Line Sequence: "
+                        + message.getEndOfMessageSequence()
+                                .getValue()
+                                .replace("\r", "[CR]")
+                                .replace("\n", "[NL]"));
+        appendString(message.getEndOfMessageSequence().getValue(), StandardCharsets.US_ASCII);
     }
 
     @Override
     protected void serializeProtocolMessageContents() {
         serializeVersion();
         serializeComment();
-        serializeCRNL();
+        serializeEndOfMessageSequence();
     }
 }

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/common/CyclicParserSerializerTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/common/CyclicParserSerializerTest.java
@@ -1,9 +1,9 @@
-/**
+/*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * <p>Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
- * <p>Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */
 package de.rub.nds.sshattacker.core.protocol.common;
 

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/parser/VersionExchangeMessageParserTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/parser/VersionExchangeMessageParserTest.java
@@ -28,12 +28,14 @@ public class VersionExchangeMessageParserTest {
                         ArrayConverter.hexStringToByteArray(
                                 "5353482d322e302d4f70656e5353485f372e380d0a"),
                         "SSH-2.0-OpenSSH_7.8",
-                        ""),
+                        "",
+                        "\r\n"),
                 Arguments.of(
                         ArrayConverter.hexStringToByteArray(
                                 "5353482d322e302d6c69627373685f302e372e300d0a"),
                         "SSH-2.0-libssh_0.7.0",
-                        ""));
+                        "",
+                        "\r\n"));
     }
 
     /**
@@ -45,11 +47,16 @@ public class VersionExchangeMessageParserTest {
      */
     @ParameterizedTest
     @MethodSource("provideTestVectors")
-    public void testParse(byte[] providedBytes, String expectedVersion, String expectedComment) {
+    public void testParse(
+            byte[] providedBytes,
+            String expectedVersion,
+            String expectedComment,
+            String expectedEndOfMessageSequence) {
         VersionExchangeMessageParser parser = new VersionExchangeMessageParser(providedBytes, 0);
         VersionExchangeMessage msg = parser.parse();
 
         assertEquals(expectedVersion, msg.getVersion().getValue());
         assertEquals(expectedComment, msg.getComment().getValue());
+        assertEquals(expectedEndOfMessageSequence, msg.getEndOfMessageSequence().getValue());
     }
 }

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/VersionExchangeMessageSerializerTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/VersionExchangeMessageSerializerTest.java
@@ -36,10 +36,14 @@ public class VersionExchangeMessageSerializerTest {
     @ParameterizedTest
     @MethodSource("provideTestVectors")
     public void testSerialize(
-            byte[] expectedBytes, String providedVersion, String providedComment) {
+            byte[] expectedBytes,
+            String providedVersion,
+            String providedComment,
+            String providedEndOfMessagSequence) {
         VersionExchangeMessage msg = new VersionExchangeMessage();
         msg.setVersion(providedVersion);
         msg.setComment(providedComment);
+        msg.setEndOfMessageSequence("\r\n");
         VersionExchangeMessageSerializer serializer = new VersionExchangeMessageSerializer(msg);
 
         assertArrayEquals(expectedBytes, serializer.serialize());


### PR DESCRIPTION
Some SSH implementations do not send a CR NL but rather a single NL as the termination character of their version exchange message. This fix changes the behaviour of the VersionExchangeMessageParser to not expect a CR.