### PR TITLE
feat: Prepare messages from Config with fallback via Chooser

### DIFF
--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/config/Config.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/config/Config.java
@@ -20,9 +20,8 @@ import java.io.InputStream;
 import java.io.Serializable;
 import java.lang.reflect.Field;
 import java.security.Security;
-import java.util.ArrayList;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.*;
+import java.util.stream.Collectors;
 import javax.xml.bind.annotation.*;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import org.apache.logging.log4j.LogManager;
@@ -58,6 +57,8 @@ public class Config implements Serializable {
 
     @XmlJavaTypeAdapter(UnformattedByteArrayAdapter.class)
     private final byte[] serverCookie;
+
+    private String endOfMessageSequence;
 
     @XmlElement(name = "clientSupportedKeyExchangeAlgorithm")
     @XmlElementWrapper
@@ -230,8 +231,11 @@ public class Config implements Serializable {
      */
     private Boolean enableEncryptionOnNewKeysMessage = true;
 
-    public Config() {
+    private NamedDHGroup defaultDHGexKeyExchangeGroup;
 
+    private KeyExchangeAlgorithm defaultEcdhKeyExchangeAlgortihm;
+
+    public Config() {
         defaultClientConnection = new OutboundConnection("client", 65222, "localhost");
         defaultServerConnection = new InboundConnection("server", 65222, "localhost");
         clientVersion = "SSH-2.0-OpenSSH_7.8";
@@ -240,10 +244,10 @@ public class Config implements Serializable {
         serverComment = clientComment;
         clientCookie = ArrayConverter.hexStringToByteArray("00000000000000000000000000000000");
         serverCookie = ArrayConverter.hexStringToByteArray("00000000000000000000000000000000");
+        endOfMessageSequence = "\r\n";
 
-        clientSupportedKeyExchangeAlgorithms = new LinkedList<>();
-        clientSupportedKeyExchangeAlgorithms.add(
-                KeyExchangeAlgorithm.DIFFIE_HELLMAN_GROUP14_SHA256);
+        clientSupportedKeyExchangeAlgorithms =
+                EnumSet.allOf(KeyExchangeAlgorithm.class).stream().collect(Collectors.toList());
         serverSupportedKeyExchangeAlgorithms =
                 new LinkedList<>(clientSupportedKeyExchangeAlgorithms);
 
@@ -288,6 +292,9 @@ public class Config implements Serializable {
 
         clientFirstKeyExchangePacketFollows = false;
         serverFirstKeyExchangePacketFollows = false;
+
+        defaultDHGexKeyExchangeGroup = NamedDHGroup.GROUP14;
+        defaultEcdhKeyExchangeAlgortihm = KeyExchangeAlgorithm.ECDH_SHA2_NISTP256;
 
         clientReserved = 0;
         serverReserved = 0;
@@ -371,6 +378,10 @@ public class Config implements Serializable {
 
     public byte[] getServerCookie() {
         return serverCookie;
+    }
+
+    public String getEndOfMessageSequence() {
+        return endOfMessageSequence;
     }
 
     public List<KeyExchangeAlgorithm> getClientSupportedKeyExchangeAlgorithms() {
@@ -736,5 +747,13 @@ public class Config implements Serializable {
 
     public void setEnableEncryptionOnNewKeysMessage(Boolean enableEncryptionOnNewKeysMessage) {
         this.enableEncryptionOnNewKeysMessage = enableEncryptionOnNewKeysMessage;
+    }
+
+    public NamedDHGroup getDefaultDHGexKeyExchangeGroup() {
+        return defaultDHGexKeyExchangeGroup;
+    }
+
+    public KeyExchangeAlgorithm getDefaultEcdhKeyExchangeAlgortihm() {
+        return defaultEcdhKeyExchangeAlgortihm;
     }
 }

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/preparator/UserAuthPasswordMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/preparator/UserAuthPasswordMessagePreparator.java
@@ -7,7 +7,6 @@
  */
 package de.rub.nds.sshattacker.core.protocol.authentication.preparator;
 
-import de.rub.nds.sshattacker.core.constants.AuthenticationMethod;
 import de.rub.nds.sshattacker.core.constants.MessageIDConstant;
 import de.rub.nds.sshattacker.core.constants.ServiceType;
 import de.rub.nds.sshattacker.core.protocol.authentication.message.UserAuthPasswordMessage;
@@ -26,7 +25,7 @@ public class UserAuthPasswordMessagePreparator
         getObject().setMessageID(MessageIDConstant.SSH_MSG_USERAUTH_REQUEST);
         getObject().setUserName(context.getConfig().getUsername(), true);
         getObject().setServiceName(ServiceType.SSH_CONNECTION, true);
-        getObject().setMethodName(AuthenticationMethod.PASSWORD, true);
+        getObject().setMethodName(context.getChooser().getAuthenticationMethod());
         getObject().setChangePassword(false);
         getObject().setPassword(context.getConfig().getPassword(), true);
     }

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelCloseMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelCloseMessagePreparator.java
@@ -22,6 +22,6 @@ public class ChannelCloseMessagePreparator extends SshMessagePreparator<ChannelC
     public void prepareMessageSpecificContents() {
         getObject().setMessageID(MessageIDConstant.SSH_MSG_CHANNEL_CLOSE);
         // TODO dummy values for fuzzing
-        getObject().setRecipientChannel(Integer.MAX_VALUE);
+        getObject().setRecipientChannel(context.getChooser().getRemoteChannel());
     }
 }

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelDataMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelDataMessagePreparator.java
@@ -22,7 +22,7 @@ public class ChannelDataMessagePreparator extends SshMessagePreparator<ChannelDa
     public void prepareMessageSpecificContents() {
         getObject().setMessageID(MessageIDConstant.SSH_MSG_CHANNEL_DATA);
         // TODO dummy values for fuzzing
-        getObject().setRecipientChannel(Integer.MAX_VALUE);
+        getObject().setRecipientChannel(context.getChooser().getRemoteChannel());
         getObject().setData(new byte[0], true);
     }
 }

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelEofMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelEofMessagePreparator.java
@@ -22,6 +22,6 @@ public class ChannelEofMessagePreparator extends SshMessagePreparator<ChannelEof
     public void prepareMessageSpecificContents() {
         getObject().setMessageID(MessageIDConstant.SSH_MSG_CHANNEL_EOF);
         // TODO dummy values for fuzzing
-        getObject().setRecipientChannel(Integer.MAX_VALUE);
+        getObject().setRecipientChannel(context.getChooser().getRemoteChannel());
     }
 }

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelExtendedDataMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelExtendedDataMessagePreparator.java
@@ -25,7 +25,7 @@ public class ChannelExtendedDataMessagePreparator
     public void prepareMessageSpecificContents() {
         getObject().setMessageID(MessageIDConstant.SSH_MSG_CHANNEL_EXTENDED_DATA);
         // TODO dummy values for fuzzing
-        getObject().setRecipientChannel(Integer.MAX_VALUE);
+        getObject().setRecipientChannel(context.getChooser().getRemoteChannel());
         getObject()
                 .setDataTypeCode(
                         ExtendedChannelDataType.SSH_EXTENDED_DATA_STDERR.getDataTypeCode());

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelFailureMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelFailureMessagePreparator.java
@@ -22,6 +22,6 @@ public class ChannelFailureMessagePreparator extends SshMessagePreparator<Channe
     public void prepareMessageSpecificContents() {
         getObject().setMessageID(MessageIDConstant.SSH_MSG_CHANNEL_FAILURE);
         // TODO: Dummy values for fuzzing
-        getObject().setRecipientChannel(Integer.MAX_VALUE);
+        getObject().setRecipientChannel(context.getChooser().getRemoteChannel());
     }
 }

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelOpenConfirmationMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelOpenConfirmationMessagePreparator.java
@@ -25,8 +25,8 @@ public class ChannelOpenConfirmationMessagePreparator
         getObject().setMessageID(MessageIDConstant.SSH_MSG_CHANNEL_OPEN_CONFIRMATION);
         // TODO dummy values for fuzzing
         getObject().setPacketSize(Integer.MAX_VALUE);
-        getObject().setRecipientChannel(Integer.MAX_VALUE);
-        getObject().setSenderChannel(Integer.MAX_VALUE);
-        getObject().setWindowSize(Integer.MAX_VALUE);
+        getObject().setRecipientChannel(context.getChooser().getRemoteChannel());
+        getObject().setSenderChannel(context.getChooser().getLocalChannel());
+        getObject().setWindowSize(context.getChooser().getWindowSize());
     }
 }

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelOpenFailureMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelOpenFailureMessagePreparator.java
@@ -24,7 +24,7 @@ public class ChannelOpenFailureMessagePreparator
     public void prepareMessageSpecificContents() {
         getObject().setMessageID(MessageIDConstant.SSH_MSG_CHANNEL_OPEN_FAILURE);
         // TODO dummy values for fuzzing
-        getObject().setRecipientChannel(Integer.MAX_VALUE);
+        getObject().setRecipientChannel(context.getChooser().getRemoteChannel());
         getObject().setReasonCode(Integer.MAX_VALUE);
         getObject().setReason("", true);
         getObject().setLanguageTag("", true);

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelRequestExecMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelRequestExecMessagePreparator.java
@@ -12,7 +12,6 @@ import de.rub.nds.sshattacker.core.constants.MessageIDConstant;
 import de.rub.nds.sshattacker.core.protocol.common.SshMessagePreparator;
 import de.rub.nds.sshattacker.core.protocol.connection.message.ChannelRequestExecMessage;
 import de.rub.nds.sshattacker.core.state.SshContext;
-import java.util.Optional;
 
 public class ChannelRequestExecMessagePreparator
         extends SshMessagePreparator<ChannelRequestExecMessage> {
@@ -25,14 +24,7 @@ public class ChannelRequestExecMessagePreparator
     @Override
     public void prepareMessageSpecificContents() {
         getObject().setMessageID(MessageIDConstant.SSH_MSG_CHANNEL_REQUEST);
-        Optional<Integer> remoteChannel = context.getRemoteChannel();
-        if (remoteChannel.isPresent()) {
-            getObject().setRecipientChannel(remoteChannel.get());
-        } else {
-            raisePreparationException(
-                    "Unable to prepare ChannelRequestExecMessage - No remote channel id set");
-            getObject().setRecipientChannel(0);
-        }
+        getObject().setRecipientChannel(context.getChooser().getRemoteChannel());
         getObject().setWantReply(context.getConfig().getReplyWanted());
         getObject().setRequestType(ChannelRequestType.EXEC, true);
         getObject().setCommand(context.getConfig().getChannelCommand(), true);

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelSuccessMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelSuccessMessagePreparator.java
@@ -22,6 +22,6 @@ public class ChannelSuccessMessagePreparator extends SshMessagePreparator<Channe
     public void prepareMessageSpecificContents() {
         getObject().setMessageID(MessageIDConstant.SSH_MSG_CHANNEL_SUCCESS);
         // TODO: Dummy values for fuzzing
-        getObject().setRecipientChannel(Integer.MAX_VALUE);
+        getObject().setRecipientChannel(context.getChooser().getRemoteChannel());
     }
 }

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelWindowAdjustMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelWindowAdjustMessagePreparator.java
@@ -24,7 +24,7 @@ public class ChannelWindowAdjustMessagePreparator
     public void prepareMessageSpecificContents() {
         getObject().setMessageID(MessageIDConstant.SSH_MSG_CHANNEL_WINDOW_ADJUST);
         // TODO dummy values for fuzzing
-        getObject().setRecipientChannel(Integer.MAX_VALUE);
+        getObject().setRecipientChannel(context.getChooser().getRemoteChannel());
         getObject().setBytesToAdd(Integer.MAX_VALUE);
     }
 }

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/DhGexKeyExchangeOldRequestMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/DhGexKeyExchangeOldRequestMessagePreparator.java
@@ -13,6 +13,7 @@ import de.rub.nds.sshattacker.core.crypto.kex.DhKeyExchange;
 import de.rub.nds.sshattacker.core.protocol.common.SshMessagePreparator;
 import de.rub.nds.sshattacker.core.protocol.transport.message.DhGexKeyExchangeOldRequestMessage;
 import de.rub.nds.sshattacker.core.state.SshContext;
+import java.util.Random;
 
 public class DhGexKeyExchangeOldRequestMessagePreparator
         extends SshMessagePreparator<DhGexKeyExchangeOldRequestMessage> {
@@ -26,19 +27,26 @@ public class DhGexKeyExchangeOldRequestMessagePreparator
     public void prepareMessageSpecificContents() {
         getObject().setMessageID(MessageIDConstant.SSH_MSG_KEX_DH_GEX_REQUEST_OLD);
         if (context.getKeyExchangeAlgorithm().isPresent()) {
-            DhKeyExchange keyExchange =
+            DhKeyExchange dhkeyExchange =
                     DhKeyExchange.newInstance(context.getKeyExchangeAlgorithm().get());
-            context.setKeyExchangeInstance(keyExchange);
+            context.setKeyExchangeInstance(dhkeyExchange);
         } else {
-            raisePreparationException(
-                    "Unable to instantiate a new DH key exchange, the negotiated key exchange algorithm is not set");
+            // Maybe raise new "missingContextContents" Exception "Unable to instantiate a new DH
+            // key exchange, the negotiated key exchange algorithm is not set");
+            DhKeyExchange dhKeyExchange =
+                    (DhKeyExchange)
+                            DhKeyExchange.newInstance(
+                                    (context.getChooser()
+                                            .getRandomKeyExchangeAlgorithm(
+                                                    new Random(),
+                                                    context.getChooser()
+                                                            .getAllSupportedDH_DHGEKeyExchange())));
+            context.setKeyExchangeInstance(dhKeyExchange);
         }
-
         DhGexOldExchangeHash dhGexOldExchangeHash =
                 DhGexOldExchangeHash.from(context.getExchangeHashInstance());
         dhGexOldExchangeHash.setPreferredGroupSize(context.getChooser().getPreferredDHGroupSize());
         context.setExchangeHashInstance(dhGexOldExchangeHash);
-
         getObject().setPreferredGroupSize(context.getChooser().getPreferredDHGroupSize());
     }
 }

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/DhGexKeyExchangeRequestMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/DhGexKeyExchangeRequestMessagePreparator.java
@@ -13,6 +13,7 @@ import de.rub.nds.sshattacker.core.crypto.kex.DhKeyExchange;
 import de.rub.nds.sshattacker.core.protocol.common.SshMessagePreparator;
 import de.rub.nds.sshattacker.core.protocol.transport.message.DhGexKeyExchangeRequestMessage;
 import de.rub.nds.sshattacker.core.state.SshContext;
+import java.util.Random;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -30,12 +31,21 @@ public class DhGexKeyExchangeRequestMessagePreparator
     public void prepareMessageSpecificContents() {
         getObject().setMessageID(MessageIDConstant.SSH_MSG_KEX_DH_GEX_REQUEST);
         if (context.getKeyExchangeAlgorithm().isPresent()) {
-            DhKeyExchange keyExchange =
+            DhKeyExchange dhkeyExchange =
                     DhKeyExchange.newInstance(context.getKeyExchangeAlgorithm().get());
-            context.setKeyExchangeInstance(keyExchange);
+            context.setKeyExchangeInstance(dhkeyExchange);
         } else {
-            raisePreparationException(
-                    "Unable to instantiate a new DH key exchange, the negotiated key exchange algorithm is not set");
+            // Maybe raise new "missingContextContents" Exception "Unable to instantiate a new DH
+            // key exchange, the negotiated key exchange algorithm is not set");
+            DhKeyExchange dhKeyExchange =
+                    (DhKeyExchange)
+                            DhKeyExchange.newInstance(
+                                    (context.getChooser()
+                                            .getRandomKeyExchangeAlgorithm(
+                                                    new Random(),
+                                                    context.getChooser()
+                                                            .getAllSupportedDH_DHGEKeyExchange())));
+            context.setKeyExchangeInstance(dhKeyExchange);
         }
 
         DhGexExchangeHash dhGexExchangeHash =

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/DhKeyExchangeInitMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/DhKeyExchangeInitMessagePreparator.java
@@ -16,6 +16,7 @@ import de.rub.nds.sshattacker.core.protocol.common.SshMessagePreparator;
 import de.rub.nds.sshattacker.core.protocol.transport.message.DhKeyExchangeInitMessage;
 import de.rub.nds.sshattacker.core.state.SshContext;
 import java.util.Optional;
+import java.util.Random;
 
 public class DhKeyExchangeInitMessagePreparator
         extends SshMessagePreparator<DhKeyExchangeInitMessage> {
@@ -28,21 +29,32 @@ public class DhKeyExchangeInitMessagePreparator
     @Override
     public void prepareMessageSpecificContents() {
         getObject().setMessageID(MessageIDConstant.SSH_MSG_KEXDH_INIT);
-        // TODO: Handle default value for key exchange algorithm in Config
         Optional<KeyExchangeAlgorithm> keyExchangeAlgorithm = context.getKeyExchangeAlgorithm();
         DhKeyExchange keyExchange;
         if (keyExchangeAlgorithm.isPresent()
                 && keyExchangeAlgorithm.get().getFlowType() == KeyExchangeFlowType.DIFFIE_HELLMAN) {
             keyExchange = DhKeyExchange.newInstance(keyExchangeAlgorithm.get());
         } else {
-            raisePreparationException(
-                    "Key exchange algorithm not negotiated or unexpected flow type, unable to generate a local key pair");
+            // Maybe raise new "missingContextContents" Exception "Key exchange algorithm not
+            // negotiated or unexpected flow type, unable to generate a local key pair");
             keyExchange =
-                    DhKeyExchange.newInstance(KeyExchangeAlgorithm.DIFFIE_HELLMAN_GROUP14_SHA256);
+                    (DhKeyExchange)
+                            DhKeyExchange.newInstance(
+                                    (context.getChooser()
+                                            .getRandomKeyExchangeAlgorithm(
+                                                    new Random(),
+                                                    context.getChooser()
+                                                            .getAllSupportedDHKeyExchange())));
         }
+        if (!(keyExchange.areGroupParametersSet())) {
+            keyExchange.setModulus(
+                    context.getConfig().getDefaultDHGexKeyExchangeGroup().getModulus());
+            keyExchange.setGenerator(
+                    context.getConfig().getDefaultDHGexKeyExchangeGroup().getGenerator());
+        }
+        ;
         keyExchange.generateLocalKeyPair();
         context.setKeyExchangeInstance(keyExchange);
-
         DhNamedExchangeHash dhNamedExchangeHash =
                 DhNamedExchangeHash.from(context.getExchangeHashInstance());
         dhNamedExchangeHash.setClientDHPublicKey(keyExchange.getLocalKeyPair().getPublic());

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/EcdhKeyExchangeInitMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/EcdhKeyExchangeInitMessagePreparator.java
@@ -43,9 +43,11 @@ public class EcdhKeyExchangeInitMessagePreparator
                     break;
             }
         } else {
-            raisePreparationException(
-                    "Key exchange algorithm not negotiate, unable to generate a local key pair");
-            keyExchange = EcdhKeyExchange.newInstance(KeyExchangeAlgorithm.ECDH_SHA2_NISTP256);
+            // Maybe raise new "missingContextContents" Exception "Key exchange algorithm not
+            // negotiate, unable to generate a local key pair");
+            keyExchange =
+                    EcdhKeyExchange.newInstance(
+                            context.getConfig().getDefaultEcdhKeyExchangeAlgortihm());
         }
         keyExchange.generateLocalKeyPair();
         context.setKeyExchangeInstance(keyExchange);

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/VersionExchangeMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/VersionExchangeMessagePreparator.java
@@ -23,14 +23,12 @@ public class VersionExchangeMessagePreparator
         if (context.isClient()) {
             getObject().setVersion(context.getChooser().getClientVersion());
             getObject().setComment(context.getChooser().getClientComment());
-            // TODO: Use chooser here
-            getObject().setEndOfMessageSequence("\r\n");
+            getObject().setEndOfMessageSequence(context.getChooser().getEndofMessageSequence());
             context.getExchangeHashInstance().setClientVersion(getObject());
         } else {
             getObject().setVersion(context.getChooser().getServerVersion());
             getObject().setComment(context.getChooser().getServerComment());
-            // TODO: Use chooser here
-            getObject().setEndOfMessageSequence("\r\n");
+            getObject().setEndOfMessageSequence(context.getChooser().getEndofMessageSequence());
             context.getExchangeHashInstance().setServerVersion(getObject());
         }
     }

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/state/Chooser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/state/Chooser.java
@@ -10,6 +10,8 @@ package de.rub.nds.sshattacker.core.state;
 import de.rub.nds.sshattacker.core.config.Config;
 import de.rub.nds.sshattacker.core.constants.*;
 import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
 
 public class Chooser {
 
@@ -36,6 +38,10 @@ public class Chooser {
 
     public String getServerComment() {
         return context.getServerComment().orElse(config.getServerComment());
+    }
+
+    public String getEndofMessageSequence() {
+        return context.getEndofMessageSequence().orElse(config.getEndOfMessageSequence());
     }
 
     // endregion
@@ -186,12 +192,40 @@ public class Chooser {
         return 8192;
     }
 
+    public List<KeyExchangeAlgorithm> getAllSupportedDHKeyExchange() {
+        return config.getClientSupportedKeyExchangeAlgorithms().stream()
+                .filter(
+                        keyExchangeAlgorithm ->
+                                keyExchangeAlgorithm.getFlowType()
+                                        == KeyExchangeFlowType.DIFFIE_HELLMAN)
+                .collect(Collectors.toList());
+    }
+
+    public List<KeyExchangeAlgorithm> getAllSupportedDH_DHGEKeyExchange() {
+        return config.getClientSupportedKeyExchangeAlgorithms().stream()
+                .filter(
+                        keyExchangeAlgorithm ->
+                                keyExchangeAlgorithm.getFlowType()
+                                                == KeyExchangeFlowType.DIFFIE_HELLMAN
+                                        || keyExchangeAlgorithm.getFlowType()
+                                                == KeyExchangeFlowType
+                                                        .DIFFIE_HELLMAN_GROUP_EXCHANGE)
+                .collect(Collectors.toList());
+    }
+
+    public KeyExchangeAlgorithm getRandomKeyExchangeAlgorithm(
+            Random random, List<KeyExchangeAlgorithm> possibleKeyExchangeAlgorithms) {
+        int randomField = random.nextInt(possibleKeyExchangeAlgorithms.size());
+        return possibleKeyExchangeAlgorithms.get(randomField);
+    }
+
     // endregion
 
     public AuthenticationMethod getAuthenticationMethod() {
         return context.getAuthenticationMethod().orElse(config.getAuthenticationMethod());
     }
 
+    // region connection
     public int getLocalChannel() {
         return context.getLocalChannel().orElse(config.getLocalChannel());
     }
@@ -207,4 +241,14 @@ public class Chooser {
     public int getPacketSize() {
         return context.getPacketSize().orElse(config.getPacketSize());
     }
+
+    public int getRemoteChannel() {
+        return context.getRemoteChannel().orElse(config.getRemoteChannel());
+    }
+
+    // endregion
+
+    // region transport
+
+    // endregion
 }

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/state/SshContext.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/state/SshContext.java
@@ -59,6 +59,9 @@ public class SshContext {
     private String serverVersion;
     /** Server comment sent alongside protocol and software version */
     private String serverComment;
+    /** Defines the end of the VersionExchangeMessage */
+    private String endofMessageSequence;
+
     // endregion
 
     // region Key Exchange Initialization
@@ -383,6 +386,10 @@ public class SshContext {
         return Optional.ofNullable(serverCookie);
     }
 
+    public Optional<String> getEndofMessageSequence() {
+        return Optional.ofNullable(endofMessageSequence);
+    }
+
     // endregion
     // region Setters for Version Exchange Fields
     public void setClientVersion(String clientVersion) {
@@ -409,6 +416,9 @@ public class SshContext {
         this.serverCookie = serverCookie;
     }
 
+    public void setEndofMessageSequence(String endMessageSequence) {
+        this.endofMessageSequence = endMessageSequence;
+    }
     // endregion
 
     // region Getters for Key Exchange Initialization Fields
@@ -880,7 +890,6 @@ public class SshContext {
     public void setChannelType(ChannelType channelType) {
         this.channelType = channelType;
     }
-
     // endregion
 
     public boolean getReceivedDisconnectMessage() {

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/common/CyclicParserSerializerTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/common/CyclicParserSerializerTest.java
@@ -10,9 +10,7 @@ package de.rub.nds.sshattacker.core.protocol.common;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import de.rub.nds.sshattacker.core.constants.KeyExchangeAlgorithm;
-import de.rub.nds.sshattacker.core.crypto.hash.DhGexExchangeHash;
-import de.rub.nds.sshattacker.core.crypto.kex.DhKeyExchange;
+import de.rub.nds.sshattacker.core.config.Config;
 import de.rub.nds.sshattacker.core.exceptions.NotImplementedException;
 import de.rub.nds.sshattacker.core.exceptions.ParserException;
 import de.rub.nds.sshattacker.core.exceptions.PreparationException;
@@ -46,15 +44,13 @@ public class CyclicParserSerializerTest {
         Security.addProvider(new BouncyCastleProvider());
     }
 
-    // TODO: Implement testParserSerializerPairs once messages can be prepared from config
-
     @TestFactory
     public Stream<DynamicTest> generateCyclicDefaultConstructorPairsDynamicTests() {
         Set<Class<? extends ProtocolMessage>> excludedClasses = new HashSet<>();
         // Exclude UnknownMessage as it is not a standardized protocol message (it is only used when
         // a message could not be parsed successfully)
         excludedClasses.add(UnknownMessage.class);
-
+        this.testClass();
         return new Reflections("de.rub.nds.sshattacker.core.protocol")
                 .getSubTypesOf(ProtocolMessage.class).stream()
                         .filter(messageClass -> !Modifier.isAbstract(messageClass.getModifiers()))
@@ -67,6 +63,26 @@ public class CyclicParserSerializerTest {
                                                         + "}",
                                                 new CyclicDefaultConstructorPairsTest(
                                                         messageClass)));
+    }
+
+    public void testClass() {
+        CyclicParserSerializerTest cp = new CyclicParserSerializerTest();
+        Set<Class<? extends ProtocolMessage>> reflect =
+                new Reflections("de.rub.nds.sshattacker.core.protocol")
+                        .getSubTypesOf(ProtocolMessage.class);
+        for (Class c : reflect) {
+            this.testMissingClassConstructor(c);
+        }
+    }
+
+    public void testMissingClassConstructor(Class someClass) {
+        for (Constructor c : someClass.getConstructors()) {
+            if (c.getParameterCount() == 1) {
+                if (c.getParameterTypes()[0].equals(Config.class)) {
+                    java.lang.System.out.println(someClass + "   True");
+                }
+            }
+        }
     }
 
     private static class CyclicDefaultConstructorPairsTest implements Executable {
@@ -107,15 +123,15 @@ public class CyclicParserSerializerTest {
                                 + "'");
             }
 
-            // Create a fresh SshContext and set the key exchange algorithm if necessary
-            SshContext context = getSshContext();
+            // Create a fresh SshContext
+            SshContext context = new SshContext();
 
             // Prepare the message given the fresh context
             try {
                 message.getHandler(context).getPreparator().prepare();
             } catch (PreparationException e) {
                 LOGGER.fatal(e);
-                fail(
+                throw new PreparationException(
                         "Caught a PreparationException while preparing message of class '"
                                 + messageClassName
                                 + "'");
@@ -190,50 +206,15 @@ public class CyclicParserSerializerTest {
             // assertEquals(message.hashCode(), parsedMessage.hashCode());
         }
 
-        private SshContext getSshContext() {
-            SshContext context = new SshContext();
-
-            // For now we need to set the key exchange algorithm accordingly whenever we prepare a
-            // message of the key exchange
-            // TODO: Remove once preparation from config is implemented
-            if (messageClass == EcdhKeyExchangeInitMessage.class) {
-                context.setKeyExchangeAlgorithm(KeyExchangeAlgorithm.ECDH_SHA2_NISTP256);
-            } else if (messageClass == DhGexKeyExchangeOldRequestMessage.class
-                    || messageClass == DhGexKeyExchangeRequestMessage.class
-                    || messageClass == DhGexKeyExchangeInitMessage.class) {
-                context.setKeyExchangeAlgorithm(
-                        KeyExchangeAlgorithm.DIFFIE_HELLMAN_GROUP_EXCHANGE_SHA256);
-            } else if (messageClass == DhKeyExchangeInitMessage.class) {
-                context.setKeyExchangeAlgorithm(KeyExchangeAlgorithm.DIFFIE_HELLMAN_GROUP14_SHA256);
+        private static Constructor<?> getDefaultMessageConstructor(Class<?> someClass) {
+            for (Constructor<?> c : someClass.getDeclaredConstructors()) {
+                if (c.getParameterCount() == 0) {
+                    return c;
+                }
             }
-
-            // TODO: Remove once preparation from config is implemented
-            if (messageClass == DhGexKeyExchangeInitMessage.class) {
-                context.setExchangeHashInstance(
-                        DhGexExchangeHash.from(context.getExchangeHashInstance()));
-                // Even though it is a DH GEX message use a named group to prevent exceptions due to
-                // a missing group
-                DhKeyExchange kex =
-                        DhKeyExchange.newInstance(
-                                KeyExchangeAlgorithm.DIFFIE_HELLMAN_GROUP14_SHA256);
-                kex.generateLocalKeyPair();
-                context.setKeyExchangeInstance(kex);
-            }
-
-            // TODO: Remove once preparation from config is implemented
-            context.setRemoteChannel(0);
-
-            return context;
+            LOGGER.warn(
+                    "Unable to find default constructor for class: " + someClass.getSimpleName());
+            return null;
         }
-    }
-
-    private static Constructor<?> getDefaultMessageConstructor(Class<?> someClass) {
-        for (Constructor<?> c : someClass.getDeclaredConstructors()) {
-            if (c.getParameterCount() == 0) {
-                return c;
-            }
-        }
-        LOGGER.warn("Unable to find default constructor for class: " + someClass.getSimpleName());
-        return null;
     }
 }


### PR DESCRIPTION
The messages are prepared with a fallback on Config via Chooser now, if the SSH-Context doesn't include the necessary contents to prepare the message or if the messages are sent out of order. So the dummy data of the messages is taken from Config now and not generated randomly. Because of that the getSshContext() method of the CyclicParserSerializerTest is not needed anymore and the messages are prepared from Config. It would make sense, to maybe raise an exception or just to log it, if the fallback on Config is used for the message preparation, that's why i added this as ToDo, that you can evaluate that again.