### PR TITLE
feat: Prepare Messages from Config with fallback via Chooser

### DIFF
--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/config/Config.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/config/Config.java
@@ -20,9 +20,8 @@ import java.io.InputStream;
 import java.io.Serializable;
 import java.lang.reflect.Field;
 import java.security.Security;
-import java.util.ArrayList;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.*;
+import java.util.stream.Collectors;
 import javax.xml.bind.annotation.*;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import org.apache.logging.log4j.LogManager;
@@ -58,6 +57,8 @@ public class Config implements Serializable {
 
     @XmlJavaTypeAdapter(UnformattedByteArrayAdapter.class)
     private final byte[] serverCookie;
+
+    private String endOfMessageSequence;
 
     @XmlElement(name = "clientSupportedKeyExchangeAlgorithm")
     @XmlElementWrapper
@@ -232,6 +233,10 @@ public class Config implements Serializable {
 
     private ChooserType chooserType = ChooserType.DEFAULT;
 
+    private NamedDHGroup defaultDHGexKeyExchangeGroup;
+
+    private KeyExchangeAlgorithm defaultEcdhKeyExchangeAlgortihm;
+
     public Config() {
 
         defaultClientConnection = new OutboundConnection("client", 65222, "localhost");
@@ -242,9 +247,10 @@ public class Config implements Serializable {
         serverComment = clientComment;
         clientCookie = ArrayConverter.hexStringToByteArray("00000000000000000000000000000000");
         serverCookie = ArrayConverter.hexStringToByteArray("00000000000000000000000000000000");
+        endOfMessageSequence = "\r\n";
 
-        clientSupportedKeyExchangeAlgorithms = new LinkedList<>();
-        clientSupportedKeyExchangeAlgorithms.add(KeyExchangeAlgorithm.ECDH_SHA2_NISTP256);
+        clientSupportedKeyExchangeAlgorithms =
+                EnumSet.allOf(KeyExchangeAlgorithm.class).stream().collect(Collectors.toList());
         serverSupportedKeyExchangeAlgorithms =
                 new LinkedList<>(clientSupportedKeyExchangeAlgorithms);
 
@@ -290,6 +296,9 @@ public class Config implements Serializable {
 
         clientFirstKeyExchangePacketFollows = false;
         serverFirstKeyExchangePacketFollows = false;
+
+        defaultDHGexKeyExchangeGroup = NamedDHGroup.GROUP14;
+        defaultEcdhKeyExchangeAlgortihm = KeyExchangeAlgorithm.ECDH_SHA2_NISTP256;
 
         clientReserved = 0;
         serverReserved = 0;
@@ -373,6 +382,10 @@ public class Config implements Serializable {
 
     public byte[] getServerCookie() {
         return serverCookie;
+    }
+
+    public String getEndOfMessageSequence() {
+        return endOfMessageSequence;
     }
 
     public List<KeyExchangeAlgorithm> getClientSupportedKeyExchangeAlgorithms() {
@@ -746,5 +759,13 @@ public class Config implements Serializable {
 
     public void setChooserType(ChooserType chooserType) {
         this.chooserType = chooserType;
+    }
+
+    public NamedDHGroup getDefaultDHGexKeyExchangeGroup() {
+        return defaultDHGexKeyExchangeGroup;
+    }
+
+    public KeyExchangeAlgorithm getDefaultEcdhKeyExchangeAlgortihm() {
+        return defaultEcdhKeyExchangeAlgortihm;
     }
 }

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/preparator/UserAuthPasswordMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/preparator/UserAuthPasswordMessagePreparator.java
@@ -7,7 +7,6 @@
  */
 package de.rub.nds.sshattacker.core.protocol.authentication.preparator;
 
-import de.rub.nds.sshattacker.core.constants.AuthenticationMethod;
 import de.rub.nds.sshattacker.core.constants.MessageIDConstant;
 import de.rub.nds.sshattacker.core.constants.ServiceType;
 import de.rub.nds.sshattacker.core.protocol.authentication.message.UserAuthPasswordMessage;
@@ -26,7 +25,7 @@ public class UserAuthPasswordMessagePreparator
         getObject().setMessageID(MessageIDConstant.SSH_MSG_USERAUTH_REQUEST);
         getObject().setUserName(chooser.getConfig().getUsername(), true);
         getObject().setServiceName(ServiceType.SSH_CONNECTION, true);
-        getObject().setMethodName(AuthenticationMethod.PASSWORD, true);
+        getObject().setMethodName(chooser.getAuthenticationMethod());
         getObject().setChangePassword(false);
         getObject().setPassword(chooser.getConfig().getPassword(), true);
     }

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelCloseMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelCloseMessagePreparator.java
@@ -22,6 +22,6 @@ public class ChannelCloseMessagePreparator extends SshMessagePreparator<ChannelC
     public void prepareMessageSpecificContents() {
         getObject().setMessageID(MessageIDConstant.SSH_MSG_CHANNEL_CLOSE);
         // TODO dummy values for fuzzing
-        getObject().setRecipientChannel(Integer.MAX_VALUE);
+        getObject().setRecipientChannel(chooser.getRemoteChannel());
     }
 }

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelDataMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelDataMessagePreparator.java
@@ -22,7 +22,7 @@ public class ChannelDataMessagePreparator extends SshMessagePreparator<ChannelDa
     public void prepareMessageSpecificContents() {
         getObject().setMessageID(MessageIDConstant.SSH_MSG_CHANNEL_DATA);
         // TODO dummy values for fuzzing
-        getObject().setRecipientChannel(Integer.MAX_VALUE);
+        getObject().setRecipientChannel(chooser.getRemoteChannel());
         getObject().setData(new byte[0], true);
     }
 }

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelEofMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelEofMessagePreparator.java
@@ -22,6 +22,6 @@ public class ChannelEofMessagePreparator extends SshMessagePreparator<ChannelEof
     public void prepareMessageSpecificContents() {
         getObject().setMessageID(MessageIDConstant.SSH_MSG_CHANNEL_EOF);
         // TODO dummy values for fuzzing
-        getObject().setRecipientChannel(Integer.MAX_VALUE);
+        getObject().setRecipientChannel(chooser.getRemoteChannel());
     }
 }

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelExtendedDataMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelExtendedDataMessagePreparator.java
@@ -25,7 +25,7 @@ public class ChannelExtendedDataMessagePreparator
     public void prepareMessageSpecificContents() {
         getObject().setMessageID(MessageIDConstant.SSH_MSG_CHANNEL_EXTENDED_DATA);
         // TODO dummy values for fuzzing
-        getObject().setRecipientChannel(Integer.MAX_VALUE);
+        getObject().setRecipientChannel(chooser.getRemoteChannel());
         getObject()
                 .setDataTypeCode(
                         ExtendedChannelDataType.SSH_EXTENDED_DATA_STDERR.getDataTypeCode());

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelFailureMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelFailureMessagePreparator.java
@@ -22,6 +22,6 @@ public class ChannelFailureMessagePreparator extends SshMessagePreparator<Channe
     public void prepareMessageSpecificContents() {
         getObject().setMessageID(MessageIDConstant.SSH_MSG_CHANNEL_FAILURE);
         // TODO: Dummy values for fuzzing
-        getObject().setRecipientChannel(Integer.MAX_VALUE);
+        getObject().setRecipientChannel(chooser.getRemoteChannel());
     }
 }

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelOpenConfirmationMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelOpenConfirmationMessagePreparator.java
@@ -25,8 +25,8 @@ public class ChannelOpenConfirmationMessagePreparator
         getObject().setMessageID(MessageIDConstant.SSH_MSG_CHANNEL_OPEN_CONFIRMATION);
         // TODO dummy values for fuzzing
         getObject().setPacketSize(Integer.MAX_VALUE);
-        getObject().setRecipientChannel(Integer.MAX_VALUE);
-        getObject().setSenderChannel(Integer.MAX_VALUE);
-        getObject().setWindowSize(Integer.MAX_VALUE);
+        getObject().setRecipientChannel(chooser.getRemoteChannel());
+        getObject().setSenderChannel(chooser.getLocalChannel());
+        getObject().setWindowSize(chooser.getWindowSize());
     }
 }

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelOpenFailureMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelOpenFailureMessagePreparator.java
@@ -23,7 +23,7 @@ public class ChannelOpenFailureMessagePreparator
     public void prepareMessageSpecificContents() {
         getObject().setMessageID(MessageIDConstant.SSH_MSG_CHANNEL_OPEN_FAILURE);
         // TODO dummy values for fuzzing
-        getObject().setRecipientChannel(Integer.MAX_VALUE);
+        getObject().setRecipientChannel(chooser.getRemoteChannel());
         getObject().setReasonCode(Integer.MAX_VALUE);
         getObject().setReason("", true);
         getObject().setLanguageTag("", true);

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelRequestExecMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelRequestExecMessagePreparator.java
@@ -12,7 +12,6 @@ import de.rub.nds.sshattacker.core.constants.MessageIDConstant;
 import de.rub.nds.sshattacker.core.protocol.common.SshMessagePreparator;
 import de.rub.nds.sshattacker.core.protocol.connection.message.ChannelRequestExecMessage;
 import de.rub.nds.sshattacker.core.workflow.chooser.Chooser;
-import java.util.Optional;
 
 public class ChannelRequestExecMessagePreparator
         extends SshMessagePreparator<ChannelRequestExecMessage> {
@@ -24,14 +23,7 @@ public class ChannelRequestExecMessagePreparator
     @Override
     public void prepareMessageSpecificContents() {
         getObject().setMessageID(MessageIDConstant.SSH_MSG_CHANNEL_REQUEST);
-        Optional<Integer> remoteChannel = chooser.getContext().getRemoteChannel();
-        if (remoteChannel.isPresent()) {
-            getObject().setRecipientChannel(remoteChannel.get());
-        } else {
-            raisePreparationException(
-                    "Unable to prepare ChannelRequestExecMessage - No remote channel id set");
-            getObject().setRecipientChannel(0);
-        }
+        getObject().setRecipientChannel(chooser.getRemoteChannel());
         getObject().setWantReply(chooser.getConfig().getReplyWanted());
         getObject().setRequestType(ChannelRequestType.EXEC, true);
         getObject().setCommand(chooser.getConfig().getChannelCommand(), true);

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelSuccessMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelSuccessMessagePreparator.java
@@ -22,6 +22,6 @@ public class ChannelSuccessMessagePreparator extends SshMessagePreparator<Channe
     public void prepareMessageSpecificContents() {
         getObject().setMessageID(MessageIDConstant.SSH_MSG_CHANNEL_SUCCESS);
         // TODO: Dummy values for fuzzing
-        getObject().setRecipientChannel(Integer.MAX_VALUE);
+        getObject().setRecipientChannel(chooser.getRemoteChannel());
     }
 }

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelWindowAdjustMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelWindowAdjustMessagePreparator.java
@@ -24,7 +24,7 @@ public class ChannelWindowAdjustMessagePreparator
     public void prepareMessageSpecificContents() {
         getObject().setMessageID(MessageIDConstant.SSH_MSG_CHANNEL_WINDOW_ADJUST);
         // TODO dummy values for fuzzing
-        getObject().setRecipientChannel(Integer.MAX_VALUE);
+        getObject().setRecipientChannel(chooser.getRemoteChannel());
         getObject().setBytesToAdd(Integer.MAX_VALUE);
     }
 }

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/DhGexKeyExchangeInitMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/DhGexKeyExchangeInitMessagePreparator.java
@@ -16,7 +16,6 @@ import de.rub.nds.sshattacker.core.crypto.kex.KeyExchange;
 import de.rub.nds.sshattacker.core.protocol.common.SshMessagePreparator;
 import de.rub.nds.sshattacker.core.protocol.transport.message.DhGexKeyExchangeInitMessage;
 import de.rub.nds.sshattacker.core.workflow.chooser.Chooser;
-import java.math.BigInteger;
 import java.util.Optional;
 import java.util.Random;
 import org.apache.logging.log4j.LogManager;
@@ -36,17 +35,35 @@ public class DhGexKeyExchangeInitMessagePreparator
     public void prepareMessageSpecificContents() {
         getObject().setMessageID(MessageIDConstant.SSH_MSG_KEX_DH_GEX_INIT);
         Optional<KeyExchange> keyExchange = chooser.getContext().getKeyExchangeInstance();
-        if (keyExchange.isPresent()
-                && keyExchange.get() instanceof DhKeyExchange
-                && ((DhKeyExchange) keyExchange.get()).areGroupParametersSet()) {
+        if (keyExchange.isPresent() && keyExchange.get() instanceof DhKeyExchange) {
             DhKeyExchange dhKeyExchange = (DhKeyExchange) keyExchange.get();
+            if (!(dhKeyExchange.areGroupParametersSet())) {
+                dhKeyExchange.setModulus(
+                        chooser.getConfig().getDefaultDHGexKeyExchangeGroup().getModulus());
+                dhKeyExchange.setGenerator(
+                        chooser.getConfig().getDefaultDHGexKeyExchangeGroup().getGenerator());
+            }
+            ;
             dhKeyExchange.generateLocalKeyPair();
             getObject().setPublicKey(dhKeyExchange.getLocalKeyPair().getPublic().getY(), true);
         } else {
-            raisePreparationException(
-                    "Key exchange instance is either not present, no DhKeyExchange or does not have its group parameters set, unable to generate a local key pair");
-            // TODO: Get public key from config if key exchange instance is not set
-            getObject().setPublicKey(new BigInteger(256, new Random()), true);
+            // ToDo Maybe implement and raise new "missingContextContents" Exception
+            DhKeyExchange dhKeyExchange =
+                    (DhKeyExchange)
+                            DhKeyExchange.newInstance(
+                                    (chooser.getRandomKeyExchangeAlgorithm(
+                                            new Random(),
+                                            chooser.getAllSupportedDH_DHGEKeyExchange())));
+            if (!(dhKeyExchange.areGroupParametersSet())) {
+                dhKeyExchange.setModulus(
+                        chooser.getConfig().getDefaultDHGexKeyExchangeGroup().getModulus());
+                dhKeyExchange.setGenerator(
+                        chooser.getConfig().getDefaultDHGexKeyExchangeGroup().getGenerator());
+            }
+            ;
+            dhKeyExchange.generateLocalKeyPair();
+            getObject().setPublicKey(dhKeyExchange.getLocalKeyPair().getPublic().getY(), true);
+            chooser.getContext().setKeyExchangeInstance(dhKeyExchange);
         }
 
         ExchangeHash exchangeHash = chooser.getContext().getExchangeHashInstance();
@@ -57,8 +74,15 @@ public class DhGexKeyExchangeInitMessagePreparator
             ((DhGexOldExchangeHash) exchangeHash)
                     .setClientDHPublicKey(getObject().getPublicKey().getValue().toByteArray());
         } else {
-            raisePreparationException(
-                    "Exchange hash instance is neither DhGexExchangeHash nor DhGexOldExchangeHash or key exchange instance is not present, unable to update exchange hash with local public key");
+            // throw "missingContextContents" Exception "Exchange hash instance is neither
+            // DhGexExchangeHash nor DhGexOldExchangeHash or key exchange instance is not present,
+            // unable to update exchange hash with local public key");
+            chooser.getContext()
+                    .setExchangeHashInstance(
+                            DhGexExchangeHash.from(chooser.getContext().getExchangeHashInstance()));
+            ExchangeHash dhexchangeHash = chooser.getContext().getExchangeHashInstance();
+            ((DhGexExchangeHash) dhexchangeHash)
+                    .setClientDHPublicKey(getObject().getPublicKey().getValue().toByteArray());
         }
     }
 }

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/DhGexKeyExchangeOldRequestMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/DhGexKeyExchangeOldRequestMessagePreparator.java
@@ -13,6 +13,7 @@ import de.rub.nds.sshattacker.core.crypto.kex.DhKeyExchange;
 import de.rub.nds.sshattacker.core.protocol.common.SshMessagePreparator;
 import de.rub.nds.sshattacker.core.protocol.transport.message.DhGexKeyExchangeOldRequestMessage;
 import de.rub.nds.sshattacker.core.workflow.chooser.Chooser;
+import java.util.Random;
 
 public class DhGexKeyExchangeOldRequestMessagePreparator
         extends SshMessagePreparator<DhGexKeyExchangeOldRequestMessage> {
@@ -30,8 +31,15 @@ public class DhGexKeyExchangeOldRequestMessagePreparator
                     DhKeyExchange.newInstance(chooser.getContext().getKeyExchangeAlgorithm().get());
             chooser.getContext().setKeyExchangeInstance(keyExchange);
         } else {
-            raisePreparationException(
-                    "Unable to instantiate a new DH key exchange, the negotiated key exchange algorithm is not set");
+            // Maybe raise new "missingContextContents" Exception "Unable to instantiate a new DH
+            // key exchange, the negotiated key exchange algorithm is not set");
+            DhKeyExchange dhKeyExchange =
+                    (DhKeyExchange)
+                            DhKeyExchange.newInstance(
+                                    (chooser.getRandomKeyExchangeAlgorithm(
+                                            new Random(),
+                                            chooser.getAllSupportedDH_DHGEKeyExchange())));
+            chooser.getContext().setKeyExchangeInstance(dhKeyExchange);
         }
 
         DhGexOldExchangeHash dhGexOldExchangeHash =

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/DhGexKeyExchangeRequestMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/DhGexKeyExchangeRequestMessagePreparator.java
@@ -13,6 +13,7 @@ import de.rub.nds.sshattacker.core.crypto.kex.DhKeyExchange;
 import de.rub.nds.sshattacker.core.protocol.common.SshMessagePreparator;
 import de.rub.nds.sshattacker.core.protocol.transport.message.DhGexKeyExchangeRequestMessage;
 import de.rub.nds.sshattacker.core.workflow.chooser.Chooser;
+import java.util.Random;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -34,8 +35,15 @@ public class DhGexKeyExchangeRequestMessagePreparator
                     DhKeyExchange.newInstance(chooser.getContext().getKeyExchangeAlgorithm().get());
             chooser.getContext().setKeyExchangeInstance(keyExchange);
         } else {
-            raisePreparationException(
-                    "Unable to instantiate a new DH key exchange, the negotiated key exchange algorithm is not set");
+            // Maybe raise new "missingContextContents" Exception "Unable to instantiate a new DH
+            // key exchange, the negotiated key exchange algorithm is not set");
+            DhKeyExchange dhKeyExchange =
+                    (DhKeyExchange)
+                            DhKeyExchange.newInstance(
+                                    (chooser.getRandomKeyExchangeAlgorithm(
+                                            new Random(),
+                                            chooser.getAllSupportedDH_DHGEKeyExchange())));
+            chooser.getContext().setKeyExchangeInstance(dhKeyExchange);
         }
 
         DhGexExchangeHash dhGexExchangeHash =

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/EcdhKeyExchangeInitMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/EcdhKeyExchangeInitMessagePreparator.java
@@ -44,9 +44,11 @@ public class EcdhKeyExchangeInitMessagePreparator
                     break;
             }
         } else {
-            raisePreparationException(
-                    "Key exchange algorithm not negotiate, unable to generate a local key pair");
-            keyExchange = EcdhKeyExchange.newInstance(KeyExchangeAlgorithm.ECDH_SHA2_NISTP256);
+            // Maybe raise new "missingContextContents" Exception "Key exchange algorithm not
+            // negotiate, unable to generate a local key pair");
+            keyExchange =
+                    EcdhKeyExchange.newInstance(
+                            chooser.getConfig().getDefaultEcdhKeyExchangeAlgortihm());
         }
         keyExchange.generateLocalKeyPair();
         chooser.getContext().setKeyExchangeInstance(keyExchange);

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/VersionExchangeMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/VersionExchangeMessagePreparator.java
@@ -24,13 +24,13 @@ public class VersionExchangeMessagePreparator
             getObject().setVersion(chooser.getClientVersion());
             getObject().setComment(chooser.getClientComment());
             // TODO: Use chooser here
-            getObject().setEndOfMessageSequence("\r\n");
+            getObject().setEndOfMessageSequence(chooser.getEndOfMessageSequence());
             chooser.getContext().getExchangeHashInstance().setClientVersion(getObject());
         } else {
             getObject().setVersion(chooser.getServerVersion());
             getObject().setComment(chooser.getServerComment());
             // TODO: Use chooser here
-            getObject().setEndOfMessageSequence("\r\n");
+            getObject().setEndOfMessageSequence(chooser.getEndOfMessageSequence());
             chooser.getContext().getExchangeHashInstance().setServerVersion(getObject());
         }
     }

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/state/SshContext.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/state/SshContext.java
@@ -68,6 +68,9 @@ public class SshContext {
     private String serverVersion;
     /** Server comment sent alongside protocol and software version */
     private String serverComment;
+    /** Defines the end of the VersionExchangeMessage */
+    private String endofMessageSequence;
+
     // endregion
 
     // region Key Exchange Initialization
@@ -402,6 +405,10 @@ public class SshContext {
         return Optional.ofNullable(serverCookie);
     }
 
+    public Optional<String> getEndofMessageSequence() {
+        return Optional.ofNullable(endofMessageSequence);
+    }
+
     // endregion
     // region Setters for Version Exchange Fields
     public void setClientVersion(String clientVersion) {
@@ -428,6 +435,9 @@ public class SshContext {
         this.serverCookie = serverCookie;
     }
 
+    public void setEndofMessageSequence(String endMessageSequence) {
+        this.endofMessageSequence = endMessageSequence;
+    }
     // endregion
 
     // region Getters for Key Exchange Initialization Fields
@@ -899,7 +909,6 @@ public class SshContext {
     public void setChannelType(ChannelType channelType) {
         this.channelType = channelType;
     }
-
     // endregion
 
     public boolean getReceivedDisconnectMessage() {

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/chooser/Chooser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/chooser/Chooser.java
@@ -11,6 +11,7 @@ import de.rub.nds.sshattacker.core.config.Config;
 import de.rub.nds.sshattacker.core.constants.*;
 import de.rub.nds.sshattacker.core.state.SshContext;
 import java.util.List;
+import java.util.Random;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -44,6 +45,7 @@ public abstract class Chooser {
 
     public abstract String getServerComment();
 
+    public abstract String getEndOfMessageSequence();
     // endregion
 
     // region Key Exchange Initialization
@@ -116,6 +118,13 @@ public abstract class Chooser {
     @SuppressWarnings("SameReturnValue")
     public abstract int getMaximalDHGroupSize();
 
+    public abstract List<KeyExchangeAlgorithm> getAllSupportedDHKeyExchange();
+
+    public abstract List<KeyExchangeAlgorithm> getAllSupportedDH_DHGEKeyExchange();
+
+    public abstract KeyExchangeAlgorithm getRandomKeyExchangeAlgorithm(
+            Random random, List<KeyExchangeAlgorithm> possibleKeyExchangeAlgorithms);
+
     // endregion
 
     public abstract AuthenticationMethod getAuthenticationMethod();
@@ -127,4 +136,6 @@ public abstract class Chooser {
     public abstract int getWindowSize();
 
     public abstract int getPacketSize();
+
+    public abstract int getRemoteChannel();
 }


### PR DESCRIPTION
The messages are prepared with a fallback on Config via Chooser now, if the SSH-Context doesn't include the necessary contents to prepare the message or if the messages are sent out of order. So the dummy data of the messages is taken from Config now and not generated randomly. Because of that the getSshContext() method of the CyclicParserSerializerTest is not needed anymore and the messages are prepared from Config. It would make sense, to maybe raise an exception or just to log it, if the fallback on Config is used for the message preparation, that's why i added this as ToDo, that you can evaluate that again.

Rebase of #47 to current master 