### PR TITLE
fix: Parsing of name lists relied upon enum name

### DIFF
--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/handler/KeyExchangeInitMessageHandler.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/handler/KeyExchangeInitMessageHandler.java
@@ -33,35 +33,35 @@ public class KeyExchangeInitMessageHandler extends SshMessageHandler<KeyExchange
         if (context.isClient()) {
             context.setServerCookie(message.getCookie().getValue());
             context.setServerSupportedKeyExchangeAlgorithms(
-                    Converter.stringToAlgorithms(
+                    Converter.nameListToEnumValues(
                             message.getKeyExchangeAlgorithms().getValue(),
                             KeyExchangeAlgorithm.class));
             context.setServerSupportedHostKeyAlgorithms(
-                    Converter.stringToAlgorithms(
+                    Converter.nameListToEnumValues(
                             message.getServerHostKeyAlgorithms().getValue(),
                             PublicKeyAuthenticationAlgorithm.class));
             context.setServerSupportedCipherAlgorithmsClientToServer(
-                    Converter.stringToAlgorithms(
+                    Converter.nameListToEnumValues(
                             message.getEncryptionAlgorithmsClientToServer().getValue(),
                             EncryptionAlgorithm.class));
             context.setServerSupportedCipherAlgorithmsServerToClient(
-                    Converter.stringToAlgorithms(
+                    Converter.nameListToEnumValues(
                             message.getEncryptionAlgorithmsServerToClient().getValue(),
                             EncryptionAlgorithm.class));
             context.setServerSupportedMacAlgorithmsClientToServer(
-                    Converter.stringToAlgorithms(
+                    Converter.nameListToEnumValues(
                             message.getMacAlgorithmsClientToServer().getValue(),
                             MacAlgorithm.class));
             context.setServerSupportedMacAlgorithmsServerToClient(
-                    Converter.stringToAlgorithms(
+                    Converter.nameListToEnumValues(
                             message.getMacAlgorithmsServerToClient().getValue(),
                             MacAlgorithm.class));
             context.setServerSupportedCompressionAlgorithmsClientToServer(
-                    Converter.stringToAlgorithms(
+                    Converter.nameListToEnumValues(
                             message.getCompressionAlgorithmsClientToServer().getValue(),
                             CompressionAlgorithm.class));
             context.setServerSupportedCompressionAlgorithmsServerToClient(
-                    Converter.stringToAlgorithms(
+                    Converter.nameListToEnumValues(
                             message.getCompressionAlgorithmsServerToClient().getValue(),
                             CompressionAlgorithm.class));
             context.setServerSupportedLanguagesClientToServer(
@@ -80,35 +80,35 @@ public class KeyExchangeInitMessageHandler extends SshMessageHandler<KeyExchange
         } else {
             context.setClientCookie(message.getCookie().getValue());
             context.setClientSupportedKeyExchangeAlgorithms(
-                    Converter.stringToAlgorithms(
+                    Converter.nameListToEnumValues(
                             message.getKeyExchangeAlgorithms().getValue(),
                             KeyExchangeAlgorithm.class));
             context.setClientSupportedHostKeyAlgorithms(
-                    Converter.stringToAlgorithms(
+                    Converter.nameListToEnumValues(
                             message.getServerHostKeyAlgorithms().getValue(),
                             PublicKeyAuthenticationAlgorithm.class));
             context.setClientSupportedCipherAlgorithmsClientToServer(
-                    Converter.stringToAlgorithms(
+                    Converter.nameListToEnumValues(
                             message.getEncryptionAlgorithmsClientToServer().getValue(),
                             EncryptionAlgorithm.class));
             context.setClientSupportedCipherAlgorithmsServerToClient(
-                    Converter.stringToAlgorithms(
+                    Converter.nameListToEnumValues(
                             message.getEncryptionAlgorithmsServerToClient().getValue(),
                             EncryptionAlgorithm.class));
             context.setClientSupportedMacAlgorithmsClientToServer(
-                    Converter.stringToAlgorithms(
+                    Converter.nameListToEnumValues(
                             message.getMacAlgorithmsClientToServer().getValue(),
                             MacAlgorithm.class));
             context.setClientSupportedMacAlgorithmsServerToClient(
-                    Converter.stringToAlgorithms(
+                    Converter.nameListToEnumValues(
                             message.getMacAlgorithmsServerToClient().getValue(),
                             MacAlgorithm.class));
             context.setClientSupportedCompressionAlgorithmsClientToServer(
-                    Converter.stringToAlgorithms(
+                    Converter.nameListToEnumValues(
                             message.getCompressionAlgorithmsClientToServer().getValue(),
                             CompressionAlgorithm.class));
             context.setClientSupportedCompressionAlgorithmsServerToClient(
-                    Converter.stringToAlgorithms(
+                    Converter.nameListToEnumValues(
                             message.getCompressionAlgorithmsServerToClient().getValue(),
                             CompressionAlgorithm.class));
             context.setClientSupportedLanguagesClientToServer(


### PR DESCRIPTION
This PR fixes a minor issue related to the parsing of name list values used during parsing of the `KeyExchangeInitMessage`. Up till now, the parsing relies on the enum name to follow a specific pattern in order to be able to successful parse an algorithm name. This method however does not work for ECDH key exchange methods with curves specified through their OID. The new implementation maps the raw string to the enum value by comparing the toString() output of the enum value to the raw string.

In addition, this fix allows the remote peer to send unknown algorithms which resulted in a parsing error before. The unknown algorithm is stripped from the list of enum values returned.