### PR TITLE
fix: Set method name length

### DIFF
--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/preparator/UserAuthPasswordMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/preparator/UserAuthPasswordMessagePreparator.java
@@ -7,6 +7,7 @@
  */
 package de.rub.nds.sshattacker.core.protocol.authentication.preparator;
 
+import de.rub.nds.sshattacker.core.constants.AuthenticationMethod;
 import de.rub.nds.sshattacker.core.constants.MessageIDConstant;
 import de.rub.nds.sshattacker.core.constants.ServiceType;
 import de.rub.nds.sshattacker.core.protocol.authentication.message.UserAuthPasswordMessage;
@@ -25,7 +26,7 @@ public class UserAuthPasswordMessagePreparator
         getObject().setMessageID(MessageIDConstant.SSH_MSG_USERAUTH_REQUEST);
         getObject().setUserName(chooser.getConfig().getUsername(), true);
         getObject().setServiceName(ServiceType.SSH_CONNECTION, true);
-        getObject().setMethodName(chooser.getAuthenticationMethod(), true);
+        getObject().setMethodName(AuthenticationMethod.PASSWORD, true);
         getObject().setChangePassword(false);
         getObject().setPassword(chooser.getConfig().getPassword(), true);
     }


### PR DESCRIPTION
This PR fixes an issue within the preparator of the `UserAuthPasswordMessage`. The authentication method name length is not properly set resulting in NPEs while serializing.