### PR TITLE
doc: Update license header to current year

### DIFF
--- a/SSH-Client/src/main/java/de/rub/nds/sshattacker/client/config/ClientCommandConfig.java
+++ b/SSH-Client/src/main/java/de/rub/nds/sshattacker/client/config/ClientCommandConfig.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Client/src/main/java/de/rub/nds/sshattacker/client/main/SshClient.java
+++ b/SSH-Client/src/main/java/de/rub/nds/sshattacker/client/main/SshClient.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/config/Config.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/config/Config.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/config/ConfigCache.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/config/ConfigCache.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/config/ConfigIO.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/config/ConfigIO.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/config/SSHDelegateConfig.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/config/SSHDelegateConfig.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/config/converter/LogLevelConverter.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/config/converter/LogLevelConverter.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/config/converter/RunningModeConverter.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/config/converter/RunningModeConverter.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/config/converter/WorkflowTraceTypeConverter.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/config/converter/WorkflowTraceTypeConverter.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/config/delegate/ClientDelegate.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/config/delegate/ClientDelegate.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/config/delegate/ConfigOutputDelegate.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/config/delegate/ConfigOutputDelegate.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/config/delegate/Delegate.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/config/delegate/Delegate.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/config/delegate/GeneralDelegate.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/config/delegate/GeneralDelegate.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/config/delegate/RunningModeDelegate.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/config/delegate/RunningModeDelegate.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/config/delegate/ServerDelegate.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/config/delegate/ServerDelegate.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/config/delegate/TimeoutDelegate.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/config/delegate/TimeoutDelegate.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/config/delegate/WorkflowInputDelegate.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/config/delegate/WorkflowInputDelegate.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/config/delegate/WorkflowOutputDelegate.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/config/delegate/WorkflowOutputDelegate.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/config/delegate/WorkflowTypeDelegate.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/config/delegate/WorkflowTypeDelegate.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/config/filter/ConfigDisplayFilter.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/config/filter/ConfigDisplayFilter.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/connection/Aliasable.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/connection/Aliasable.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/connection/AliasedConnection.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/connection/AliasedConnection.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/connection/InboundConnection.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/connection/InboundConnection.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/connection/OutboundConnection.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/connection/OutboundConnection.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/AnsiColors.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/AnsiColors.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/AuthenticationMethod.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/AuthenticationMethod.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/BinaryPacketConstants.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/BinaryPacketConstants.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/BinaryPacketField.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/BinaryPacketField.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/Bits.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/Bits.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/ChannelRequestType.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/ChannelRequestType.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/ChannelType.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/ChannelType.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/CharConstants.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/CharConstants.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/ChooserType.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/ChooserType.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/CompressionAlgorithm.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/CompressionAlgorithm.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/CompressionMethod.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/CompressionMethod.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/CryptoConstants.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/CryptoConstants.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/DataFormatConstants.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/DataFormatConstants.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/DisconnectReason.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/DisconnectReason.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/ECPointFormat.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/ECPointFormat.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/EncryptionAlgorithm.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/EncryptionAlgorithm.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/EncryptionAlgorithmFamily.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/EncryptionAlgorithmFamily.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/EncryptionAlgorithmType.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/EncryptionAlgorithmType.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/EncryptionMode.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/EncryptionMode.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/ExtendedChannelDataType.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/ExtendedChannelDataType.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/GOSTCurve.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/GOSTCurve.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/GlobalRequestType.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/GlobalRequestType.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/KeyDerivationLabels.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/KeyDerivationLabels.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/KeyExchangeAlgorithm.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/KeyExchangeAlgorithm.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/KeyExchangeFlowType.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/KeyExchangeFlowType.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/KeyExchangeInitConstants.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/KeyExchangeInitConstants.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/Language.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/Language.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/MacAlgorithm.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/MacAlgorithm.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/MessageIDConstant.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/MessageIDConstant.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/NamedDHGroup.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/NamedDHGroup.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/NamedGroup.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/NamedGroup.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/PacketLayerType.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/PacketLayerType.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/PublicKeyAuthenticationAlgorithm.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/PublicKeyAuthenticationAlgorithm.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/RunningModeType.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/RunningModeType.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/ServiceType.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/ServiceType.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/SshMessageConstants.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/SshMessageConstants.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/KeyDerivation.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/KeyDerivation.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/cipher/ChaCha20Poly1305Cipher.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/cipher/ChaCha20Poly1305Cipher.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/cipher/CipherFactory.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/cipher/CipherFactory.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/cipher/DecryptionCipher.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/cipher/DecryptionCipher.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/cipher/EncryptionCipher.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/cipher/EncryptionCipher.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/cipher/JavaCipher.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/cipher/JavaCipher.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/cipher/NoneCipher.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/cipher/NoneCipher.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/CurveFactory.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/CurveFactory.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurve.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurve.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveBrainpoolP256R1.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveBrainpoolP256R1.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveBrainpoolP384R1.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveBrainpoolP384R1.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveBrainpoolP512R1.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveBrainpoolP512R1.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveOverF2m.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveOverF2m.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveOverFp.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveOverFp.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveSECP160K1.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveSECP160K1.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveSECP160R1.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveSECP160R1.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveSECP160R2.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveSECP160R2.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveSECP192K1.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveSECP192K1.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveSECP192R1.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveSECP192R1.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveSECP224K1.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveSECP224K1.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveSECP224R1.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveSECP224R1.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveSECP256K1.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveSECP256K1.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveSECP256R1.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveSECP256R1.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveSECP384R1.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveSECP384R1.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveSECP521R1.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveSECP521R1.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveSECT163K1.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveSECT163K1.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveSECT163R1.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveSECT163R1.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveSECT163R2.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveSECT163R2.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveSECT193R1.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveSECT193R1.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveSECT193R2.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveSECT193R2.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveSECT233K1.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveSECT233K1.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveSECT233R1.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveSECT233R1.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveSECT239K1.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveSECT239K1.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveSECT283K1.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveSECT283K1.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveSECT283R1.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveSECT283R1.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveSECT409K1.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveSECT409K1.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveSECT409R1.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveSECT409R1.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveSECT571K1.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveSECT571K1.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveSECT571R1.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/EllipticCurveSECT571R1.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/FieldElement.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/FieldElement.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/FieldElementF2m.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/FieldElementF2m.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/FieldElementFp.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/FieldElementFp.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/Point.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/Point.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/PointFormatter.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/ec/PointFormatter.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/hash/DhGexExchangeHash.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/hash/DhGexExchangeHash.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/hash/DhGexOldExchangeHash.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/hash/DhGexOldExchangeHash.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/hash/DhNamedExchangeHash.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/hash/DhNamedExchangeHash.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/hash/EcdhExchangeHash.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/hash/EcdhExchangeHash.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/hash/ExchangeHash.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/hash/ExchangeHash.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/kex/DhBasedKeyExchange.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/kex/DhBasedKeyExchange.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/kex/DhKeyExchange.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/kex/DhKeyExchange.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/kex/EcdhKeyExchange.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/kex/EcdhKeyExchange.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/kex/KeyExchange.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/kex/KeyExchange.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/kex/XCurveEcdhKeyExchange.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/kex/XCurveEcdhKeyExchange.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/keys/CustomDhPrivateKey.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/keys/CustomDhPrivateKey.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/keys/CustomDhPublicKey.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/keys/CustomDhPublicKey.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/keys/CustomEcPrivateKey.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/keys/CustomEcPrivateKey.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/keys/CustomEcPublicKey.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/keys/CustomEcPublicKey.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/keys/CustomKeyPair.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/keys/CustomKeyPair.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/keys/XCurveEcPrivateKey.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/keys/XCurveEcPrivateKey.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/keys/XCurveEcPublicKey.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/keys/XCurveEcPublicKey.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/mac/JavaMac.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/mac/JavaMac.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/mac/MacFactory.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/mac/MacFactory.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/mac/NoneMac.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/mac/NoneMac.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/mac/UMac.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/mac/UMac.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/mac/WrappedMac.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/mac/WrappedMac.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/exceptions/AdjustmentException.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/exceptions/AdjustmentException.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/exceptions/BouncyCastleNotLoadedException.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/exceptions/BouncyCastleNotLoadedException.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/exceptions/ConfigurationException.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/exceptions/ConfigurationException.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/exceptions/ContextHandlingException.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/exceptions/ContextHandlingException.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/exceptions/CryptoException.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/exceptions/CryptoException.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/exceptions/DecryptionException.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/exceptions/DecryptionException.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/exceptions/InvalidChooserTypeException.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/exceptions/InvalidChooserTypeException.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/exceptions/ModificationException.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/exceptions/ModificationException.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/exceptions/NotImplementedException.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/exceptions/NotImplementedException.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/exceptions/ParserException.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/exceptions/ParserException.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/exceptions/PreparationException.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/exceptions/PreparationException.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/exceptions/TransportHandlerConnectException.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/exceptions/TransportHandlerConnectException.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/exceptions/WorkflowExecutionException.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/exceptions/WorkflowExecutionException.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/AbstractPacket.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/AbstractPacket.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/BinaryPacket.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/BinaryPacket.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/BlobPacket.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/BlobPacket.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/PacketCryptoComputations.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/PacketCryptoComputations.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/cipher/PacketChaCha20Poly1305Cipher.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/cipher/PacketChaCha20Poly1305Cipher.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/cipher/PacketCipher.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/cipher/PacketCipher.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/cipher/PacketCipherFactory.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/cipher/PacketCipherFactory.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/cipher/PacketGCMCipher.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/cipher/PacketGCMCipher.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/cipher/PacketMacedCipher.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/cipher/PacketMacedCipher.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/cipher/keys/KeySet.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/cipher/keys/KeySet.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/cipher/keys/KeySetGenerator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/cipher/keys/KeySetGenerator.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/compressor/Compressor.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/compressor/Compressor.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/compressor/Decompressor.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/compressor/Decompressor.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/compressor/PacketCompressor.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/compressor/PacketCompressor.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/compressor/PacketDecompressor.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/compressor/PacketDecompressor.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/compressor/compression/Compression.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/compressor/compression/Compression.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/compressor/compression/DeflateCompression.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/compressor/compression/DeflateCompression.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/compressor/compression/NoneCompression.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/compressor/compression/NoneCompression.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/crypto/AbstractPacketDecryptor.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/crypto/AbstractPacketDecryptor.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/crypto/AbstractPacketEncryptor.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/crypto/AbstractPacketEncryptor.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/crypto/PacketCryptoUnit.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/crypto/PacketCryptoUnit.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/crypto/PacketDecryptor.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/crypto/PacketDecryptor.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/crypto/PacketEncryptor.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/crypto/PacketEncryptor.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/layer/AbstractPacketLayer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/layer/AbstractPacketLayer.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/layer/BinaryPacketLayer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/layer/BinaryPacketLayer.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/layer/BlobPacketLayer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/layer/BlobPacketLayer.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/layer/PacketLayerFactory.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/layer/PacketLayerFactory.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/parser/AbstractPacketParser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/parser/AbstractPacketParser.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/parser/BinaryPacketParser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/parser/BinaryPacketParser.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/parser/BlobPacketParser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/parser/BlobPacketParser.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/preparator/AbstractPacketPreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/preparator/AbstractPacketPreparator.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/preparator/BinaryPacketPreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/preparator/BinaryPacketPreparator.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/preparator/BlobPacketPreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/preparator/BlobPacketPreparator.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/serializer/AbstractPacketSerializer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/serializer/AbstractPacketSerializer.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/serializer/BinaryPacketSerializer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/serializer/BinaryPacketSerializer.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/serializer/BlobPacketSerializer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/serializer/BlobPacketSerializer.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/handler/UserAuthBannerMessageHandler.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/handler/UserAuthBannerMessageHandler.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/handler/UserAuthFailureMessageHandler.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/handler/UserAuthFailureMessageHandler.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/handler/UserAuthPasswordMessageHandler.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/handler/UserAuthPasswordMessageHandler.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/handler/UserAuthSuccessMessageHandler.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/handler/UserAuthSuccessMessageHandler.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/message/UserAuthBannerMessage.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/message/UserAuthBannerMessage.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/message/UserAuthFailureMessage.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/message/UserAuthFailureMessage.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/message/UserAuthPasswordMessage.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/message/UserAuthPasswordMessage.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/message/UserAuthRequestMessage.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/message/UserAuthRequestMessage.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/message/UserAuthSuccessMessage.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/message/UserAuthSuccessMessage.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/parser/UserAuthBannerMessageParser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/parser/UserAuthBannerMessageParser.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/parser/UserAuthFailureMessageParser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/parser/UserAuthFailureMessageParser.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/parser/UserAuthPasswordMessageParser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/parser/UserAuthPasswordMessageParser.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/parser/UserAuthSuccessMessageParser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/parser/UserAuthSuccessMessageParser.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/preparator/UserAuthBannerMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/preparator/UserAuthBannerMessagePreparator.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/preparator/UserAuthFailureMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/preparator/UserAuthFailureMessagePreparator.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/preparator/UserAuthPasswordMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/preparator/UserAuthPasswordMessagePreparator.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/preparator/UserAuthSuccessMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/preparator/UserAuthSuccessMessagePreparator.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/serializer/UserAuthBannerMessageSerializer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/serializer/UserAuthBannerMessageSerializer.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/serializer/UserAuthFailureMessageSerializer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/serializer/UserAuthFailureMessageSerializer.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/serializer/UserAuthPasswordMessageSerializer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/serializer/UserAuthPasswordMessageSerializer.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/serializer/UserAuthRequestMessageSerializer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/serializer/UserAuthRequestMessageSerializer.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/serializer/UserAuthSuccessMessageSerializer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/serializer/UserAuthSuccessMessageSerializer.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/common/Handler.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/common/Handler.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/common/ModifiableVariableHolder.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/common/ModifiableVariableHolder.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/common/Parser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/common/Parser.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/common/Preparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/common/Preparator.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/common/ProtocolMessage.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/common/ProtocolMessage.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/common/ProtocolMessageHandler.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/common/ProtocolMessageHandler.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/common/ProtocolMessageParser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/common/ProtocolMessageParser.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/common/ProtocolMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/common/ProtocolMessagePreparator.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/common/ProtocolMessageSerializer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/common/ProtocolMessageSerializer.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/common/Serializer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/common/Serializer.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/common/SshMessage.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/common/SshMessage.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/common/SshMessageHandler.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/common/SshMessageHandler.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/common/SshMessageParser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/common/SshMessageParser.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/common/SshMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/common/SshMessagePreparator.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/common/SshMessageSerializer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/common/SshMessageSerializer.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/common/layer/MessageLayer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/common/layer/MessageLayer.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/handler/ChannelCloseMessageHandler.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/handler/ChannelCloseMessageHandler.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/handler/ChannelDataMessageHandler.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/handler/ChannelDataMessageHandler.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/handler/ChannelEofMessageHandler.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/handler/ChannelEofMessageHandler.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/handler/ChannelExtendedDataMessageHandler.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/handler/ChannelExtendedDataMessageHandler.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/handler/ChannelFailureMessageHandler.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/handler/ChannelFailureMessageHandler.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/handler/ChannelOpenConfirmationMessageHandler.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/handler/ChannelOpenConfirmationMessageHandler.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/handler/ChannelOpenFailureMessageHandler.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/handler/ChannelOpenFailureMessageHandler.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/handler/ChannelOpenMessageHandler.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/handler/ChannelOpenMessageHandler.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/handler/ChannelRequestExecMessageHandler.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/handler/ChannelRequestExecMessageHandler.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/handler/ChannelSuccessMessageHandler.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/handler/ChannelSuccessMessageHandler.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/handler/ChannelWindowAdjustMessageHandler.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/handler/ChannelWindowAdjustMessageHandler.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/handler/RequestFailureMessageHandler.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/handler/RequestFailureMessageHandler.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/handler/RequestSuccessMessageHandler.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/handler/RequestSuccessMessageHandler.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/handler/TcpIpForwardCancelMessageHandler.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/handler/TcpIpForwardCancelMessageHandler.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/handler/TcpIpForwardRequestMessageHandler.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/handler/TcpIpForwardRequestMessageHandler.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/message/ChannelCloseMessage.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/message/ChannelCloseMessage.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/message/ChannelDataMessage.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/message/ChannelDataMessage.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/message/ChannelEofMessage.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/message/ChannelEofMessage.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/message/ChannelExtendedDataMessage.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/message/ChannelExtendedDataMessage.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/message/ChannelFailureMessage.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/message/ChannelFailureMessage.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/message/ChannelMessage.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/message/ChannelMessage.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/message/ChannelOpenConfirmationMessage.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/message/ChannelOpenConfirmationMessage.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/message/ChannelOpenFailureMessage.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/message/ChannelOpenFailureMessage.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/message/ChannelOpenMessage.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/message/ChannelOpenMessage.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/message/ChannelRequestExecMessage.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/message/ChannelRequestExecMessage.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/message/ChannelRequestMessage.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/message/ChannelRequestMessage.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/message/ChannelSuccessMessage.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/message/ChannelSuccessMessage.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/message/ChannelWindowAdjustMessage.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/message/ChannelWindowAdjustMessage.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/message/GlobalRequestMessage.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/message/GlobalRequestMessage.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/message/RequestFailureMessage.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/message/RequestFailureMessage.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/message/RequestSuccessMessage.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/message/RequestSuccessMessage.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/message/TcpIpForwardCancelMessage.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/message/TcpIpForwardCancelMessage.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/message/TcpIpForwardMessage.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/message/TcpIpForwardMessage.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/message/TcpIpForwardRequestMessage.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/message/TcpIpForwardRequestMessage.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/parser/ChannelCloseMessageParser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/parser/ChannelCloseMessageParser.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/parser/ChannelDataMessageParser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/parser/ChannelDataMessageParser.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/parser/ChannelEofMessageParser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/parser/ChannelEofMessageParser.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/parser/ChannelExtendedDataMessageParser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/parser/ChannelExtendedDataMessageParser.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/parser/ChannelFailureMessageParser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/parser/ChannelFailureMessageParser.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/parser/ChannelMessageParser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/parser/ChannelMessageParser.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/parser/ChannelOpenConfirmationMessageParser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/parser/ChannelOpenConfirmationMessageParser.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/parser/ChannelOpenFailureMessageParser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/parser/ChannelOpenFailureMessageParser.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/parser/ChannelOpenMessageParser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/parser/ChannelOpenMessageParser.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/parser/ChannelRequestExecMessageParser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/parser/ChannelRequestExecMessageParser.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/parser/ChannelRequestMessageParser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/parser/ChannelRequestMessageParser.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/parser/ChannelSuccessMessageParser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/parser/ChannelSuccessMessageParser.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/parser/ChannelWindowAdjustMessageParser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/parser/ChannelWindowAdjustMessageParser.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/parser/GlobalRequestMessageParser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/parser/GlobalRequestMessageParser.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/parser/RequestFailureMessageParser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/parser/RequestFailureMessageParser.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/parser/RequestSuccessMessageParser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/parser/RequestSuccessMessageParser.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/parser/TcpIpForwardCancelMessageParser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/parser/TcpIpForwardCancelMessageParser.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/parser/TcpIpForwardMessageParser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/parser/TcpIpForwardMessageParser.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/parser/TcpIpForwardRequestMessageParser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/parser/TcpIpForwardRequestMessageParser.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelCloseMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelCloseMessagePreparator.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelDataMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelDataMessagePreparator.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelEofMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelEofMessagePreparator.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelExtendedDataMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelExtendedDataMessagePreparator.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelFailureMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelFailureMessagePreparator.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelOpenConfirmationMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelOpenConfirmationMessagePreparator.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelOpenFailureMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelOpenFailureMessagePreparator.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelOpenMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelOpenMessagePreparator.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelRequestExecMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelRequestExecMessagePreparator.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelSuccessMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelSuccessMessagePreparator.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelWindowAdjustMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/ChannelWindowAdjustMessagePreparator.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/RequestFailureMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/RequestFailureMessagePreparator.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/RequestSuccessMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/RequestSuccessMessagePreparator.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/TcpIpForwardCancelMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/TcpIpForwardCancelMessagePreparator.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/TcpIpForwardRequestMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/preparator/TcpIpForwardRequestMessagePreparator.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/serializer/ChannelDataMessageSerializer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/serializer/ChannelDataMessageSerializer.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/serializer/ChannelExtendedDataMessageSerializer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/serializer/ChannelExtendedDataMessageSerializer.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/serializer/ChannelMessageSerializer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/serializer/ChannelMessageSerializer.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/serializer/ChannelOpenConfirmationMessageSerializer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/serializer/ChannelOpenConfirmationMessageSerializer.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/serializer/ChannelOpenFailureMessageSerializer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/serializer/ChannelOpenFailureMessageSerializer.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/serializer/ChannelOpenMessageSerializer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/serializer/ChannelOpenMessageSerializer.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/serializer/ChannelRequestExecMessageSerializer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/serializer/ChannelRequestExecMessageSerializer.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/serializer/ChannelRequestMessageSerializer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/serializer/ChannelRequestMessageSerializer.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/serializer/ChannelWindowAdjustMessageSerializer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/serializer/ChannelWindowAdjustMessageSerializer.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/serializer/GlobalRequestMessageSerializer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/serializer/GlobalRequestMessageSerializer.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/serializer/RequestFailureMessageSerializer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/serializer/RequestFailureMessageSerializer.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/serializer/RequestSuccessMessageSerializer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/serializer/RequestSuccessMessageSerializer.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/serializer/TcpIpForwardCancelMessageSerializer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/serializer/TcpIpForwardCancelMessageSerializer.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/serializer/TcpIpForwardMessageSerializer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/serializer/TcpIpForwardMessageSerializer.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/serializer/TcpIpForwardRequestMessageSerializer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/connection/serializer/TcpIpForwardRequestMessageSerializer.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/handler/DebugMessageHandler.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/handler/DebugMessageHandler.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/handler/DhGexKeyExchangeGroupMessageHandler.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/handler/DhGexKeyExchangeGroupMessageHandler.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/handler/DhGexKeyExchangeInitMessageHandler.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/handler/DhGexKeyExchangeInitMessageHandler.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/handler/DhGexKeyExchangeOldRequestMessageHandler.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/handler/DhGexKeyExchangeOldRequestMessageHandler.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/handler/DhGexKeyExchangeReplyMessageHandler.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/handler/DhGexKeyExchangeReplyMessageHandler.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/handler/DhGexKeyExchangeRequestMessageHandler.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/handler/DhGexKeyExchangeRequestMessageHandler.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/handler/DhKeyExchangeInitMessageHandler.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/handler/DhKeyExchangeInitMessageHandler.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/handler/DhKeyExchangeReplyMessageHandler.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/handler/DhKeyExchangeReplyMessageHandler.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/handler/DisconnectMessageHandler.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/handler/DisconnectMessageHandler.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/handler/EcdhKeyExchangeInitMessageHandler.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/handler/EcdhKeyExchangeInitMessageHandler.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/handler/EcdhKeyExchangeReplyMessageHandler.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/handler/EcdhKeyExchangeReplyMessageHandler.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/handler/IgnoreMessageHandler.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/handler/IgnoreMessageHandler.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/handler/KeyExchangeInitMessageHandler.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/handler/KeyExchangeInitMessageHandler.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/handler/NewKeysMessageHandler.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/handler/NewKeysMessageHandler.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/handler/RsaKeyExchangePubkeyMessageHandler.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/handler/RsaKeyExchangePubkeyMessageHandler.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/handler/ServiceAcceptMessageHandler.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/handler/ServiceAcceptMessageHandler.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/handler/ServiceRequestMessageHandler.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/handler/ServiceRequestMessageHandler.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/handler/UnimplementedMessageHandler.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/handler/UnimplementedMessageHandler.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/handler/UnknownMessageHandler.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/handler/UnknownMessageHandler.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/handler/VersionExchangeMessageHandler.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/handler/VersionExchangeMessageHandler.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/message/DebugMessage.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/message/DebugMessage.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/message/DhGexKeyExchangeGroupMessage.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/message/DhGexKeyExchangeGroupMessage.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/message/DhGexKeyExchangeInitMessage.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/message/DhGexKeyExchangeInitMessage.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/message/DhGexKeyExchangeOldRequestMessage.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/message/DhGexKeyExchangeOldRequestMessage.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/message/DhGexKeyExchangeReplyMessage.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/message/DhGexKeyExchangeReplyMessage.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/message/DhGexKeyExchangeRequestMessage.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/message/DhGexKeyExchangeRequestMessage.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/message/DhKeyExchangeInitMessage.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/message/DhKeyExchangeInitMessage.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/message/DhKeyExchangeReplyMessage.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/message/DhKeyExchangeReplyMessage.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/message/DisconnectMessage.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/message/DisconnectMessage.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/message/EcdhKeyExchangeInitMessage.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/message/EcdhKeyExchangeInitMessage.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/message/EcdhKeyExchangeReplyMessage.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/message/EcdhKeyExchangeReplyMessage.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/message/IgnoreMessage.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/message/IgnoreMessage.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/message/KeyExchangeInitMessage.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/message/KeyExchangeInitMessage.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/message/NewKeysMessage.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/message/NewKeysMessage.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/message/RsaKeyExchangePubkeyMessage.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/message/RsaKeyExchangePubkeyMessage.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/message/ServiceAcceptMessage.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/message/ServiceAcceptMessage.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/message/ServiceRequestMessage.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/message/ServiceRequestMessage.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/message/UnimplementedMessage.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/message/UnimplementedMessage.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/message/UnknownMessage.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/message/UnknownMessage.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/message/VersionExchangeMessage.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/message/VersionExchangeMessage.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/parser/DebugMessageParser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/parser/DebugMessageParser.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/parser/DhGexKeyExchangeGroupMessageParser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/parser/DhGexKeyExchangeGroupMessageParser.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/parser/DhGexKeyExchangeInitMessageParser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/parser/DhGexKeyExchangeInitMessageParser.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/parser/DhGexKeyExchangeOldRequestMessageParser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/parser/DhGexKeyExchangeOldRequestMessageParser.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/parser/DhGexKeyExchangeReplyMessageParser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/parser/DhGexKeyExchangeReplyMessageParser.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/parser/DhGexKeyExchangeRequestMessageParser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/parser/DhGexKeyExchangeRequestMessageParser.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/parser/DhKeyExchangeInitMessageParser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/parser/DhKeyExchangeInitMessageParser.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/parser/DhKeyExchangeReplyMessageParser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/parser/DhKeyExchangeReplyMessageParser.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/parser/DisconnectMessageParser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/parser/DisconnectMessageParser.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/parser/EcdhKeyExchangeInitMessageParser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/parser/EcdhKeyExchangeInitMessageParser.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/parser/EcdhKeyExchangeReplyMessageParser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/parser/EcdhKeyExchangeReplyMessageParser.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/parser/IgnoreMessageParser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/parser/IgnoreMessageParser.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/parser/KeyExchangeInitMessageParser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/parser/KeyExchangeInitMessageParser.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/parser/NewKeysMessageParser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/parser/NewKeysMessageParser.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/parser/RsaKeyExchangePubkeyMessageParser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/parser/RsaKeyExchangePubkeyMessageParser.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/parser/ServiceAcceptMessageParser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/parser/ServiceAcceptMessageParser.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/parser/ServiceRequestMessageParser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/parser/ServiceRequestMessageParser.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/parser/UnimplementedMessageParser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/parser/UnimplementedMessageParser.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/parser/UnknownMessageParser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/parser/UnknownMessageParser.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/parser/VersionExchangeMessageParser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/parser/VersionExchangeMessageParser.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/DebugMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/DebugMessagePreparator.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/DhGexKeyExchangeGroupMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/DhGexKeyExchangeGroupMessagePreparator.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/DhGexKeyExchangeInitMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/DhGexKeyExchangeInitMessagePreparator.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/DhGexKeyExchangeOldRequestMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/DhGexKeyExchangeOldRequestMessagePreparator.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/DhGexKeyExchangeReplyMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/DhGexKeyExchangeReplyMessagePreparator.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/DhGexKeyExchangeRequestMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/DhGexKeyExchangeRequestMessagePreparator.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/DhKeyExchangeInitMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/DhKeyExchangeInitMessagePreparator.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/DhKeyExchangeReplyMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/DhKeyExchangeReplyMessagePreparator.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/DisconnectMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/DisconnectMessagePreparator.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/EcdhKeyExchangeInitMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/EcdhKeyExchangeInitMessagePreparator.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/EcdhKeyExchangeReplyMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/EcdhKeyExchangeReplyMessagePreparator.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/IgnoreMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/IgnoreMessagePreparator.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/KeyExchangeInitMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/KeyExchangeInitMessagePreparator.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/NewKeysMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/NewKeysMessagePreparator.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/RsaKeyExchangePubkeyMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/RsaKeyExchangePubkeyMessagePreparator.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/ServiceAcceptMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/ServiceAcceptMessagePreparator.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/ServiceRequestMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/ServiceRequestMessagePreparator.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/UnimplementedMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/UnimplementedMessagePreparator.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/VersionExchangeMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/VersionExchangeMessagePreparator.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/DebugMessageSerializer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/DebugMessageSerializer.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/DhGexKeyExchangeGroupMessageSerializer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/DhGexKeyExchangeGroupMessageSerializer.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/DhGexKeyExchangeInitMessageSerializer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/DhGexKeyExchangeInitMessageSerializer.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/DhGexKeyExchangeOldRequestMessageSerializer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/DhGexKeyExchangeOldRequestMessageSerializer.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/DhGexKeyExchangeReplyMessageSerializer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/DhGexKeyExchangeReplyMessageSerializer.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/DhGexKeyExchangeRequestMessageSerializer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/DhGexKeyExchangeRequestMessageSerializer.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/DhKeyExchangeInitMessageSerializer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/DhKeyExchangeInitMessageSerializer.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/DhKeyExchangeReplyMessageSerializer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/DhKeyExchangeReplyMessageSerializer.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/DisconnectMessageSerializer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/DisconnectMessageSerializer.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/EcdhKeyExchangeInitMessageSerializer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/EcdhKeyExchangeInitMessageSerializer.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/EcdhKeyExchangeReplyMessageSerializer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/EcdhKeyExchangeReplyMessageSerializer.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/IgnoreMessageSerializer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/IgnoreMessageSerializer.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/KeyExchangeInitMessageSerializer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/KeyExchangeInitMessageSerializer.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/NewKeysMessageSerializer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/NewKeysMessageSerializer.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/RsaKeyExchangePubkeyMessageSerializer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/RsaKeyExchangePubkeyMessageSerializer.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/ServiceAcceptMessageSerializer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/ServiceAcceptMessageSerializer.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/ServiceRequestMessageSerializer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/ServiceRequestMessageSerializer.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/UnimplementedMessageSerializer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/UnimplementedMessageSerializer.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/UnknownMessageSerializer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/UnknownMessageSerializer.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/VersionExchangeMessageSerializer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/VersionExchangeMessageSerializer.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/util/AlgorithmPicker.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/util/AlgorithmPicker.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/state/ContextContainer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/state/ContextContainer.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/state/SshContext.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/state/SshContext.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/state/State.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/state/State.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/util/Converter.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/util/Converter.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/util/RsaPublicKey.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/util/RsaPublicKey.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/util/RsaPublicKeyParser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/util/RsaPublicKeyParser.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/DefaultWorkflowExecutor.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/DefaultWorkflowExecutor.java
@@ -1,14 +1,13 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */
 package de.rub.nds.sshattacker.core.workflow;
 
 import de.rub.nds.sshattacker.core.config.ConfigIO;
-import de.rub.nds.sshattacker.core.connection.AliasedConnection;
 import de.rub.nds.sshattacker.core.exceptions.PreparationException;
 import de.rub.nds.sshattacker.core.exceptions.WorkflowExecutionException;
 import de.rub.nds.sshattacker.core.state.SshContext;

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/ThreadedServerWorkflowExecutor.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/ThreadedServerWorkflowExecutor.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/WorkflowExecutor.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/WorkflowExecutor.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/WorkflowExecutorRunnable.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/WorkflowExecutorRunnable.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/WorkflowTrace.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/WorkflowTrace.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/WorkflowTraceNormalizer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/WorkflowTraceNormalizer.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/WorkflowTraceSerializer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/WorkflowTraceSerializer.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */
@@ -15,14 +15,11 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.StringReader;
-import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
-import javax.xml.bind.Marshaller;
 import javax.xml.bind.Unmarshaller;
 import javax.xml.bind.util.JAXBSource;
 import javax.xml.stream.XMLInputFactory;
@@ -33,7 +30,6 @@ import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.stream.StreamResult;
-import javax.xml.transform.stream.StreamSource;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -96,8 +92,7 @@ public class WorkflowTraceSerializer {
             transformer.setOutputProperty(OutputKeys.INDENT, "yes");
             transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
             transformer.transform(
-                    new JAXBSource(context, workflowTrace),
-                    new StreamResult(xmlOutputStream));
+                    new JAXBSource(context, workflowTrace), new StreamResult(xmlOutputStream));
 
             String xml_text = xmlOutputStream.toString();
             // and we modify all line separators to the system dependant line separator

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/WorkflowTraceUtil.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/WorkflowTraceUtil.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/action/ActivateEncryptionAction.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/action/ActivateEncryptionAction.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/action/ChangeCompressionAction.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/action/ChangeCompressionAction.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/action/ChangePacketLayerAction.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/action/ChangePacketLayerAction.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/action/ConnectionBoundAction.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/action/ConnectionBoundAction.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/action/DeactivateEncryptionAction.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/action/DeactivateEncryptionAction.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/action/GeneralAction.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/action/GeneralAction.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/action/MessageAction.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/action/MessageAction.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/action/ReceiveAction.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/action/ReceiveAction.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/action/ReceivingAction.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/action/ReceivingAction.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/action/SendAction.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/action/SendAction.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/action/SendingAction.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/action/SendingAction.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/action/SshAction.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/action/SshAction.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/action/executor/MessageActionResult.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/action/executor/MessageActionResult.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/action/executor/ReceiveMessageHelper.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/action/executor/ReceiveMessageHelper.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/action/executor/SendMessageHelper.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/action/executor/SendMessageHelper.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/action/executor/WorkflowExecutorType.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/action/executor/WorkflowExecutorType.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/chooser/Chooser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/chooser/Chooser.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/chooser/ChooserFactory.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/chooser/ChooserFactory.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/chooser/DefaultChooser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/chooser/DefaultChooser.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/factory/MessageActionFactory.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/factory/MessageActionFactory.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/factory/WorkflowConfigurationFactory.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/factory/WorkflowConfigurationFactory.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */
@@ -20,7 +20,6 @@ import de.rub.nds.sshattacker.core.protocol.common.ProtocolMessage;
 import de.rub.nds.sshattacker.core.protocol.connection.message.*;
 import de.rub.nds.sshattacker.core.protocol.transport.message.*;
 import de.rub.nds.sshattacker.core.protocol.util.AlgorithmPicker;
-import de.rub.nds.sshattacker.core.state.State;
 import de.rub.nds.sshattacker.core.workflow.WorkflowTrace;
 import de.rub.nds.sshattacker.core.workflow.action.*;
 import de.rub.nds.tlsattacker.transport.ConnectionEndType;
@@ -55,15 +54,13 @@ public class WorkflowConfigurationFactory {
             case FULL:
                 return createFullWorkflowTrace();
             case DYNAMIC_KEYEXCHANGE:
-                //TODO Implement dynamic workflow
+                // TODO Implement dynamic workflow
             case DYNAMIC_AUTHPASSWORD:
             case DYNAMIC_FULL:
             default:
                 throw new ConfigurationException(
                         "Unknown WorkflowTraceType" + workflowTraceType.name());
         }
-
-
     }
 
     private AliasedConnection getConnection() {

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/factory/WorkflowTraceType.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/factory/WorkflowTraceType.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/filter/DefaultFilter.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/filter/DefaultFilter.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/filter/Filter.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/filter/Filter.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/filter/FilterFactory.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/filter/FilterFactory.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/filter/FilterType.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/filter/FilterType.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/crypto/KeyDerivationTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/crypto/KeyDerivationTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/crypto/kex/EcdhKeyExchangeTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/crypto/kex/EcdhKeyExchangeTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/crypto/kex/XCurveEcdhKeyExchangeTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/crypto/kex/XCurveEcdhKeyExchangeTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/crypto/mac/UMacTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/crypto/mac/UMacTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/AlgorithmPickerTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/AlgorithmPickerTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/authentication/parser/UserAuthBannerMessageParserTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/authentication/parser/UserAuthBannerMessageParserTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/authentication/parser/UserAuthFailureMessageParserTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/authentication/parser/UserAuthFailureMessageParserTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/authentication/parser/UserAuthSuccessMessageParserTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/authentication/parser/UserAuthSuccessMessageParserTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/authentication/serializer/UserAuthBannerMessageSerializerTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/authentication/serializer/UserAuthBannerMessageSerializerTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/authentication/serializer/UserAuthFailureMessageSerializerTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/authentication/serializer/UserAuthFailureMessageSerializerTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/authentication/serializer/UserAuthPasswordMessageSerializerTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/authentication/serializer/UserAuthPasswordMessageSerializerTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/authentication/serializer/UserAuthSuccessMessageSerializerTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/authentication/serializer/UserAuthSuccessMessageSerializerTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/common/CyclicParserSerializerTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/common/CyclicParserSerializerTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/connection/parser/ChannelCloseMessageParserTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/connection/parser/ChannelCloseMessageParserTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/connection/parser/ChannelDataMessageParserTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/connection/parser/ChannelDataMessageParserTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/connection/parser/ChannelEofMessageParserTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/connection/parser/ChannelEofMessageParserTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/connection/parser/ChannelExtendedDataMessageParserTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/connection/parser/ChannelExtendedDataMessageParserTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/connection/parser/ChannelFailureMessageParserTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/connection/parser/ChannelFailureMessageParserTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/connection/parser/ChannelOpenConfirmationMessageParserTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/connection/parser/ChannelOpenConfirmationMessageParserTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/connection/parser/ChannelOpenFailureMessageParserTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/connection/parser/ChannelOpenFailureMessageParserTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/connection/parser/ChannelOpenMessageParserTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/connection/parser/ChannelOpenMessageParserTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/connection/parser/ChannelSuccessMessageParserTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/connection/parser/ChannelSuccessMessageParserTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/connection/parser/ChannelWindowAdjustMessageParserTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/connection/parser/ChannelWindowAdjustMessageParserTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/connection/parser/RequestFailureMessageParserTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/connection/parser/RequestFailureMessageParserTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/connection/parser/RequestSuccessMessageParserTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/connection/parser/RequestSuccessMessageParserTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/connection/serializer/ChannelCloseMessageSerializerTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/connection/serializer/ChannelCloseMessageSerializerTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/connection/serializer/ChannelDataMessageSerializerTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/connection/serializer/ChannelDataMessageSerializerTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/connection/serializer/ChannelEofMessageSerializerTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/connection/serializer/ChannelEofMessageSerializerTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/connection/serializer/ChannelExtendedDataMessageSerializerTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/connection/serializer/ChannelExtendedDataMessageSerializerTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/connection/serializer/ChannelFailureMessageSerializerTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/connection/serializer/ChannelFailureMessageSerializerTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/connection/serializer/ChannelOpenConfirmationMessageSerializerTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/connection/serializer/ChannelOpenConfirmationMessageSerializerTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/connection/serializer/ChannelOpenFailureMessageSerializerTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/connection/serializer/ChannelOpenFailureMessageSerializerTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/connection/serializer/ChannelOpenMessageSerializerTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/connection/serializer/ChannelOpenMessageSerializerTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/connection/serializer/ChannelSuccessMessageSerializerTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/connection/serializer/ChannelSuccessMessageSerializerTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/connection/serializer/ChannelWindowAdjustMessageSerializerTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/connection/serializer/ChannelWindowAdjustMessageSerializerTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/connection/serializer/RequestFailureMessageSerializerTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/connection/serializer/RequestFailureMessageSerializerTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/connection/serializer/RequestSuccessMessageSerializerTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/connection/serializer/RequestSuccessMessageSerializerTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/parser/DebugMessageParserTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/parser/DebugMessageParserTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/parser/DhGexKeyExchangeGroupMessageParserTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/parser/DhGexKeyExchangeGroupMessageParserTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/parser/DhGexKeyExchangeReplyMessageParserTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/parser/DhGexKeyExchangeReplyMessageParserTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/parser/DhKeyExchangeReplyMessageParserTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/parser/DhKeyExchangeReplyMessageParserTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/parser/DisconnectMessageParserTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/parser/DisconnectMessageParserTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/parser/EcdhKeyExchangeInitMessageParserTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/parser/EcdhKeyExchangeInitMessageParserTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/parser/EcdhKeyExchangeReplyMessageParserTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/parser/EcdhKeyExchangeReplyMessageParserTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/parser/IgnoreMessageParserTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/parser/IgnoreMessageParserTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/parser/KeyExchangeInitMessageParserTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/parser/KeyExchangeInitMessageParserTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/parser/NewKeysMessageParserTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/parser/NewKeysMessageParserTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/parser/ServiceAcceptMessageParserTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/parser/ServiceAcceptMessageParserTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/parser/ServiceRequestMessageParserTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/parser/ServiceRequestMessageParserTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/parser/UnimplementedMessageParserTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/parser/UnimplementedMessageParserTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/parser/VersionExchangeMessageParserTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/parser/VersionExchangeMessageParserTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/DebugMessageSerializerTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/DebugMessageSerializerTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/DhGexKeyExchangeInitMessageSerializerTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/DhGexKeyExchangeInitMessageSerializerTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/DhGexKeyExchangeOldRequestMessageSerializerTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/DhGexKeyExchangeOldRequestMessageSerializerTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/DhGexKeyExchangeRequestMessageSerializerTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/DhGexKeyExchangeRequestMessageSerializerTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/DhKeyExchangeInitMessageSerializerTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/DhKeyExchangeInitMessageSerializerTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/DisconnectMessageSerializerTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/DisconnectMessageSerializerTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/EcdhKeyExchangeInitMessageSerializerTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/EcdhKeyExchangeInitMessageSerializerTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/EcdhKeyExchangeReplyMessageSerializerTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/EcdhKeyExchangeReplyMessageSerializerTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/IgnoreMessageSerializerTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/IgnoreMessageSerializerTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/KeyExchangeInitMessageSerializerTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/KeyExchangeInitMessageSerializerTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/NewKeysMessageSerializerTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/NewKeysMessageSerializerTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/ServiceAcceptMessageSerializerTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/ServiceAcceptMessageSerializerTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/ServiceRequestMessageSerializerTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/ServiceRequestMessageSerializerTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/UnimplementedMessageSerializerTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/UnimplementedMessageSerializerTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/VersionExchangeMessageSerializerTest.java
+++ b/SSH-Core/src/test/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/VersionExchangeMessageSerializerTest.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/executing/NetcatWorkflow.java
+++ b/SSH-Core/src/test/java/executing/NetcatWorkflow.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Core/src/test/java/executing/NetcatWorkflowFactory.java
+++ b/SSH-Core/src/test/java/executing/NetcatWorkflowFactory.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/SSH-Project-Template/src/main/java/de/rub/nds/sshattacker/template/Project.java
+++ b/SSH-Project-Template/src/main/java/de/rub/nds/sshattacker/template/Project.java
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/license_header_plain.txt
+++ b/license_header_plain.txt
@@ -1,7 +1,7 @@
 /*
  * SSH-Attacker - A Modular Penetration Testing Framework for SSH
  *
- * Copyright 2014-2021 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ * Copyright 2014-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
  *
  * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
  */


### PR DESCRIPTION
We haven't updated the license header to 2022 yet. This PR simply updates the text file containing the license header and subsequently adjusts each and every automatically generated license header within the project. As spotless is responsible for updating the license header, some files may have been formatted using spotless (if they didn't comply to the configured codestyle rules).