### PR TITLE
feat: Improved Log4J Logging

### DIFF
--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/common/ProtocolMessageParser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/common/ProtocolMessageParser.java
@@ -46,7 +46,7 @@ public abstract class ProtocolMessageParser<T extends ProtocolMessage<T>> extend
 
     private void setCompleteResultingMessage() {
         message.setCompleteResultingMessage(getAlreadyParsed());
-        LOGGER.debug(
+        LOGGER.trace(
                 "CompleteResultMessage: "
                         + ArrayConverter.bytesToHexString(
                                 message.getCompleteResultingMessage().getValue()));

--- a/SSH-Core/src/main/resources/log4j2.xml
+++ b/SSH-Core/src/main/resources/log4j2.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<Configuration xmlns="http://logging.apache.org/log4j/2.0/config">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%highlight{%d{HH:mm:ss.SSS} [%t] %-5level %logger{-4} - %replace{%msg}{\r?\n}{&#x0A;  }%n}{FATAL=Bright Red,ERROR=Red,WARN=Yellow,INFO=Blue,DEBUG=Normal,TRACE=Dim White}" disableAnsi="false"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Logger name="de.rub.nds" level="debug" additivity="false">
+            <AppenderRef ref="Console"/>
+        </Logger>
+        <Root level="error">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
This PR aims to increase readability of SSH-Attacker logs by introducing a custom Log4J configuration file. Most notable changes include:

- Package name is trimmed to not include the `de.rub.nds.sshattacker` prefix
- Colorization of log messages depending on their level:
  - Fatal: Bright red
  - Error: Red
  - Warn: Yellow
  - Info: Blue
  - Debug: Normal
  - Trace: Dim White
- Two spaces of indent after each newline if log message includes multiline text

Before merging, this PR should be discussed in the next SSH-Attacker meeting. Changes that may arise will be amended to the commit.