### PR TITLE
Fix exception during workflow serialization

### DIFF
--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/action/SendMangerSecretAction.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/action/SendMangerSecretAction.java
@@ -33,6 +33,20 @@ public class SendMangerSecretAction extends SendAction {
 
     private final byte[] encodedSecret;
 
+    /** Creates the action using the default connection alias */
+    public SendMangerSecretAction() {
+        this(new byte[0]);
+    }
+
+    /**
+     * Creates the action using a custom connection alias
+     *
+     * @param connectionAlias The custom connection alias
+     */
+    public SendMangerSecretAction(String connectionAlias) {
+        this(new byte[0], connectionAlias);
+    }
+
     /**
      * Creates the action using the default connection alias
      *
@@ -44,7 +58,7 @@ public class SendMangerSecretAction extends SendAction {
     }
 
     /**
-     * Creates teh action using a custom connection alias
+     * Creates the action using a custom connection alias
      *
      * @param encodedSecret The OAEP encoded shared secret
      * @param connectionAlias The custom connection alias


### PR DESCRIPTION
Because the SendMangerSecretAction had no default constructor, workflow serialization would fail as it tries to access the default constructor with no parameters.
The error only occured when checking for Manger's oracle with the attacks module, as the action is only used there.
This PR adds this missing default constructor.