### PR TITLE
fix: Allow SSH-Attacker project as submodule

### DIFF
--- a/SSH-Client/pom.xml
+++ b/SSH-Client/pom.xml
@@ -33,7 +33,7 @@
                 <configuration>
                     <filesets>
                         <fileset>
-                            <directory>${main.basedir}/apps</directory>
+                            <directory>${maven.multiModuleProjectDirectory}/apps</directory>
                         </fileset>
                     </filesets>
                 </configuration>

--- a/SSH-Server/pom.xml
+++ b/SSH-Server/pom.xml
@@ -34,7 +34,7 @@
                 <configuration>
                     <filesets>
                         <fileset>
-                            <directory>${main.basedir}/apps</directory>
+                            <directory>${maven.multiModuleProjectDirectory}/apps</directory>
                         </fileset>
                     </filesets>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
                                         <destFileName>${project.build.finalName}.${project.packaging}</destFileName>
                                     </artifactItem>
                                 </artifactItems>
-                                <outputDirectory>${project.parent.basedir}/apps</outputDirectory>
+                                <outputDirectory>${maven.multiModuleProjectDirectory}/apps</outputDirectory>
                             </configuration>
                         </execution>
                         <execution>
@@ -99,7 +99,7 @@
                                 <goal>copy-dependencies</goal>
                             </goals>
                             <configuration>
-                                <outputDirectory>${project.parent.basedir}/apps/lib</outputDirectory>
+                                <outputDirectory>${maven.multiModuleProjectDirectory}/apps/lib</outputDirectory>
                                 <!--Ensures only runnable dependencies are included-->
                                 <includeScope>compile</includeScope>
                             </configuration>


### PR DESCRIPTION
This PR is similar to https://github.com/tls-attacker/TLS-Attacker-Development/pull/894 and enables SSH-Attacker to be used as a submodule in other projects. For more details refer to the PR made to TLS-Attacker.