### PR TITLE
fix: Broken serialization of Config class

### DIFF
--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/config/Config.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/config/Config.java
@@ -263,8 +263,12 @@ public class Config implements Serializable {
     /** The password used for authentication method password */
     private String password;
     /** The List of responses used for UserAuthInfoResponseMessage */
-    private List preConfiguredAuthResponses = new ArrayList();
+    @XmlElement(name = "preConfiguredAuthResponse")
+    @XmlElementWrapper
+    private List<AuthenticationResponse> preConfiguredAuthResponses;
     /** The List of user keys for public key authentication */
+    @XmlElement(name = "userKey")
+    @XmlElementWrapper
     private final List<SshPublicKey<?, ?>> userKeys;
     // endregion
 
@@ -339,6 +343,8 @@ public class Config implements Serializable {
      * List of filter types, that should be applied on the workflow(or copy) before saving the
      * trace.
      */
+    @XmlElement(name = "outputFilter")
+    @XmlElementWrapper
     private List<FilterType> outputFilters;
     /** The path to save the workflow trace as output */
     private String workflowOutput = null;
@@ -733,8 +739,14 @@ public class Config implements Serializable {
         username = "sshattacker";
         password = "bydahirsch";
 
-        preConfiguredAuthResponses.add(List.of(new AuthenticationResponse("bydahirsch", false)));
-        preConfiguredAuthResponses.add(List.of(new AuthenticationResponse(false)));
+        preConfiguredAuthResponses = new LinkedList<>();
+        AuthenticationResponse preConfiguredAuthResponse1 = new AuthenticationResponse();
+        preConfiguredAuthResponse1.add(
+                new AuthenticationResponse.ResponseEntry("bydahirsch", false));
+        preConfiguredAuthResponses.add(preConfiguredAuthResponse1);
+        AuthenticationResponse preConfiguredAuthResponse2 = new AuthenticationResponse();
+        preConfiguredAuthResponse2.add(new AuthenticationResponse.ResponseEntry(false));
+        preConfiguredAuthResponses.add(preConfiguredAuthResponse2);
 
         // sshkey generated with "openssl ecparam -name secp521r1 -genkey -out key.pem"
         // pubkey for authorized_keys file on host generated with "ssh-keygen -y -f key.pem >
@@ -1255,7 +1267,7 @@ public class Config implements Serializable {
         return serviceName;
     }
 
-    public List getPreConfiguredAuthResponses() {
+    public List<AuthenticationResponse> getPreConfiguredAuthResponses() {
         return preConfiguredAuthResponses;
     }
 
@@ -1280,7 +1292,8 @@ public class Config implements Serializable {
         this.serviceName = serviceName;
     }
 
-    public void setPreConfiguredAuthResponses(List preConfiguredAuthResponses) {
+    public void setPreConfiguredAuthResponses(
+            List<AuthenticationResponse> preConfiguredAuthResponses) {
         this.preConfiguredAuthResponses = preConfiguredAuthResponses;
     }
     // endregion

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/AuthenticationPrompt.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/AuthenticationPrompt.java
@@ -12,68 +12,200 @@ import de.rub.nds.modifiablevariable.integer.ModifiableInteger;
 import de.rub.nds.modifiablevariable.singlebyte.ModifiableByte;
 import de.rub.nds.modifiablevariable.string.ModifiableString;
 import de.rub.nds.sshattacker.core.util.Converter;
+import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
+import java.util.*;
+import javax.xml.bind.annotation.*;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
-public class AuthenticationPrompt {
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.FIELD)
+public class AuthenticationPrompt implements List<AuthenticationPrompt.PromptEntry>, Serializable {
 
-    private ModifiableInteger promptLength;
-    private ModifiableString prompt;
-    private ModifiableByte echo;
+    @XmlElementWrapper
+    @XmlElement(name = "promptEntry")
+    private final List<PromptEntry> promptEntries = new ArrayList<>();
 
-    public AuthenticationPrompt() {}
+    @XmlAccessorType(XmlAccessType.FIELD)
+    public static class PromptEntry {
 
-    public ModifiableInteger getPromptLength() {
-        return promptLength;
-    }
+        private ModifiableInteger promptLength;
+        private ModifiableString prompt;
+        private ModifiableByte echo;
 
-    public void setPromptLength(ModifiableInteger promptLength) {
-        this.promptLength = promptLength;
-    }
+        public PromptEntry() {}
 
-    public void setPromptLength(int promptLength) {
-        this.promptLength =
-                ModifiableVariableFactory.safelySetValue(this.promptLength, promptLength);
-    }
-
-    public ModifiableString getPrompt() {
-        return prompt;
-    }
-
-    public void setPrompt(ModifiableString prompt) {
-        this.prompt = prompt;
-    }
-
-    public void setPrompt(String prompt) {
-        this.prompt = ModifiableVariableFactory.safelySetValue(this.prompt, prompt);
-    }
-
-    public void setPrompt(ModifiableString prompt, boolean adjustLengthField) {
-        if (adjustLengthField) {
-            this.setPromptLength(prompt.getValue().getBytes(StandardCharsets.UTF_8).length);
+        public ModifiableInteger getPromptLength() {
+            return promptLength;
         }
-        this.prompt = prompt;
-    }
 
-    public void setPrompt(String prompt, boolean adjustLengthField) {
-        if (adjustLengthField) {
-            this.setPromptLength(prompt.getBytes(StandardCharsets.UTF_8).length);
+        public void setPromptLength(ModifiableInteger promptLength) {
+            this.promptLength = promptLength;
         }
-        this.prompt = ModifiableVariableFactory.safelySetValue(this.prompt, prompt);
+
+        public void setPromptLength(int promptLength) {
+            this.promptLength =
+                    ModifiableVariableFactory.safelySetValue(this.promptLength, promptLength);
+        }
+
+        public ModifiableString getPrompt() {
+            return prompt;
+        }
+
+        public void setPrompt(ModifiableString prompt) {
+            this.prompt = prompt;
+        }
+
+        public void setPrompt(String prompt) {
+            this.prompt = ModifiableVariableFactory.safelySetValue(this.prompt, prompt);
+        }
+
+        public void setPrompt(ModifiableString prompt, boolean adjustLengthField) {
+            if (adjustLengthField) {
+                this.setPromptLength(prompt.getValue().getBytes(StandardCharsets.UTF_8).length);
+            }
+            this.prompt = prompt;
+        }
+
+        public void setPrompt(String prompt, boolean adjustLengthField) {
+            if (adjustLengthField) {
+                this.setPromptLength(prompt.getBytes(StandardCharsets.UTF_8).length);
+            }
+            this.prompt = ModifiableVariableFactory.safelySetValue(this.prompt, prompt);
+        }
+
+        public ModifiableByte getEcho() {
+            return echo;
+        }
+
+        public void setEcho(ModifiableByte echo) {
+            this.echo = echo;
+        }
+
+        public void setEcho(Byte echo) {
+            this.echo = ModifiableVariableFactory.safelySetValue(this.echo, echo);
+        }
+
+        public void setEcho(boolean echo) {
+            setEcho(Converter.booleanToByte(echo));
+        }
     }
 
-    public ModifiableByte getEcho() {
-        return echo;
+    // region List interface methods
+    @Override
+    public int size() {
+        return promptEntries.size();
     }
 
-    public void setEcho(ModifiableByte echo) {
-        this.echo = echo;
+    @Override
+    public boolean isEmpty() {
+        return promptEntries.isEmpty();
     }
 
-    public void setEcho(Byte echo) {
-        this.echo = ModifiableVariableFactory.safelySetValue(this.echo, echo);
+    @Override
+    public boolean contains(Object o) {
+        return promptEntries.contains(o);
     }
 
-    public void setEcho(boolean echo) {
-        setEcho(Converter.booleanToByte(echo));
+    @Override
+    public Iterator<PromptEntry> iterator() {
+        return promptEntries.iterator();
     }
+
+    @Override
+    public Object[] toArray() {
+        return promptEntries.toArray();
+    }
+
+    @Override
+    public <T> T[] toArray(@NonNull T[] a) {
+        return promptEntries.toArray(a);
+    }
+
+    @Override
+    public boolean add(PromptEntry promptEntry) {
+        return promptEntries.add(promptEntry);
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        return promptEntries.remove(o);
+    }
+
+    @SuppressWarnings("SlowListContainsAll")
+    @Override
+    public boolean containsAll(@NonNull Collection<?> c) {
+        return promptEntries.containsAll(c);
+    }
+
+    @Override
+    public boolean addAll(@NonNull Collection<? extends PromptEntry> c) {
+        return promptEntries.addAll(c);
+    }
+
+    @Override
+    public boolean addAll(int index, @NonNull Collection<? extends PromptEntry> c) {
+        return promptEntries.addAll(c);
+    }
+
+    @Override
+    public boolean removeAll(@NonNull Collection<?> c) {
+        return promptEntries.removeAll(c);
+    }
+
+    @Override
+    public boolean retainAll(@NonNull Collection<?> c) {
+        return promptEntries.retainAll(c);
+    }
+
+    @Override
+    public void clear() {
+        promptEntries.clear();
+    }
+
+    @Override
+    public PromptEntry get(int index) {
+        return promptEntries.get(index);
+    }
+
+    @Override
+    public PromptEntry set(int index, PromptEntry element) {
+        return promptEntries.set(index, element);
+    }
+
+    @Override
+    public void add(int index, PromptEntry element) {
+        promptEntries.add(index, element);
+    }
+
+    @Override
+    public PromptEntry remove(int index) {
+        return promptEntries.remove(index);
+    }
+
+    @Override
+    public int indexOf(Object o) {
+        return promptEntries.indexOf(o);
+    }
+
+    @Override
+    public int lastIndexOf(Object o) {
+        return promptEntries.lastIndexOf(o);
+    }
+
+    @Override
+    public ListIterator<PromptEntry> listIterator() {
+        return promptEntries.listIterator();
+    }
+
+    @Override
+    public ListIterator<PromptEntry> listIterator(int index) {
+        return promptEntries.listIterator(index);
+    }
+
+    @Override
+    public List<PromptEntry> subList(int fromIndex, int toIndex) {
+        return promptEntries.subList(fromIndex, toIndex);
+    }
+    // endregion
 }

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/AuthenticationResponse.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/AuthenticationResponse.java
@@ -12,68 +12,200 @@ import de.rub.nds.modifiablevariable.integer.ModifiableInteger;
 import de.rub.nds.modifiablevariable.string.ModifiableString;
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
+import java.util.*;
+import javax.xml.bind.annotation.*;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
-public class AuthenticationResponse implements Serializable {
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.FIELD)
+public class AuthenticationResponse
+        implements List<AuthenticationResponse.ResponseEntry>, Serializable {
 
-    private ModifiableInteger responseLength;
-    private ModifiableString response;
-    private boolean executed;
+    @XmlElementWrapper
+    @XmlElement(name = "responseEntry")
+    private final List<ResponseEntry> responseEntries = new ArrayList<>();
 
-    public AuthenticationResponse() {}
+    @XmlAccessorType(XmlAccessType.FIELD)
+    public static class ResponseEntry implements Serializable {
 
-    public AuthenticationResponse(boolean executed) {
-        setExecuted(executed);
-    }
+        private ModifiableInteger responseLength;
+        private ModifiableString response;
+        private boolean executed;
 
-    public AuthenticationResponse(String response, boolean executed) {
-        setResponse(response, true);
-        setExecuted(executed);
-    }
+        public ResponseEntry() {}
 
-    public ModifiableInteger getResponseLength() {
-        return responseLength;
-    }
-
-    public void setResponseLength(ModifiableInteger responseLength) {
-        this.responseLength = responseLength;
-    }
-
-    public void setResponseLength(int responseLength) {
-        this.responseLength =
-                ModifiableVariableFactory.safelySetValue(this.responseLength, responseLength);
-    }
-
-    public ModifiableString getResponse() {
-        return response;
-    }
-
-    public void setResponse(ModifiableString response) {
-        this.response = response;
-    }
-
-    public void setResponse(String response) {
-        this.response = ModifiableVariableFactory.safelySetValue(this.response, response);
-    }
-
-    public void setResponse(ModifiableString response, boolean adjustLengthField) {
-        if (adjustLengthField) {
-            setResponseLength(response.getValue().getBytes(StandardCharsets.UTF_8).length);
+        public ResponseEntry(boolean executed) {
+            setExecuted(executed);
         }
-        this.response = response;
-    }
 
-    public void setResponse(String response, boolean adjustLengthField) {
-        if (adjustLengthField) {
-            setResponseLength(response.getBytes(StandardCharsets.UTF_8).length);
+        public ResponseEntry(String response, boolean executed) {
+            setResponse(response, true);
+            setExecuted(executed);
         }
-        this.response = ModifiableVariableFactory.safelySetValue(this.response, response);
+
+        public ModifiableInteger getResponseLength() {
+            return responseLength;
+        }
+
+        public void setResponseLength(ModifiableInteger responseLength) {
+            this.responseLength = responseLength;
+        }
+
+        public void setResponseLength(int responseLength) {
+            this.responseLength =
+                    ModifiableVariableFactory.safelySetValue(this.responseLength, responseLength);
+        }
+
+        public ModifiableString getResponse() {
+            return response;
+        }
+
+        public void setResponse(ModifiableString response) {
+            this.response = response;
+        }
+
+        public void setResponse(String response) {
+            this.response = ModifiableVariableFactory.safelySetValue(this.response, response);
+        }
+
+        public void setResponse(ModifiableString response, boolean adjustLengthField) {
+            if (adjustLengthField) {
+                setResponseLength(response.getValue().getBytes(StandardCharsets.UTF_8).length);
+            }
+            this.response = response;
+        }
+
+        public void setResponse(String response, boolean adjustLengthField) {
+            if (adjustLengthField) {
+                setResponseLength(response.getBytes(StandardCharsets.UTF_8).length);
+            }
+            this.response = ModifiableVariableFactory.safelySetValue(this.response, response);
+        }
+
+        public boolean isExecuted() {
+            return executed;
+        }
+
+        public void setExecuted(boolean executed) {
+            this.executed = executed;
+        }
     }
 
-    public boolean isExecuted() {
-        return executed;
+    // region List interface methods
+    @Override
+    public int size() {
+        return responseEntries.size();
     }
 
-    public void setExecuted(boolean executed) {
-        this.executed = executed;
+    @Override
+    public boolean isEmpty() {
+        return responseEntries.isEmpty();
     }
+
+    @Override
+    public boolean contains(Object o) {
+        return responseEntries.contains(o);
+    }
+
+    @Override
+    public Iterator<ResponseEntry> iterator() {
+        return responseEntries.iterator();
+    }
+
+    @Override
+    public Object[] toArray() {
+        return responseEntries.toArray();
+    }
+
+    @Override
+    public <T> T[] toArray(T[] a) {
+        return responseEntries.toArray(a);
+    }
+
+    @Override
+    public boolean add(ResponseEntry responseEntry) {
+        return responseEntries.add(responseEntry);
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        return responseEntries.remove(o);
+    }
+
+    @SuppressWarnings("SlowListContainsAll")
+    @Override
+    public boolean containsAll(@NonNull Collection<?> c) {
+        return responseEntries.containsAll(c);
+    }
+
+    @Override
+    public boolean addAll(@NonNull Collection<? extends ResponseEntry> c) {
+        return responseEntries.addAll(c);
+    }
+
+    @Override
+    public boolean addAll(int index, @NonNull Collection<? extends ResponseEntry> c) {
+        return responseEntries.addAll(c);
+    }
+
+    @Override
+    public boolean removeAll(@NonNull Collection<?> c) {
+        return responseEntries.removeAll(c);
+    }
+
+    @Override
+    public boolean retainAll(@NonNull Collection<?> c) {
+        return responseEntries.retainAll(c);
+    }
+
+    @Override
+    public void clear() {
+        responseEntries.clear();
+    }
+
+    @Override
+    public ResponseEntry get(int index) {
+        return responseEntries.get(index);
+    }
+
+    @Override
+    public ResponseEntry set(int index, ResponseEntry element) {
+        return responseEntries.set(index, element);
+    }
+
+    @Override
+    public void add(int index, ResponseEntry element) {
+        responseEntries.add(index, element);
+    }
+
+    @Override
+    public ResponseEntry remove(int index) {
+        return responseEntries.remove(index);
+    }
+
+    @Override
+    public int indexOf(Object o) {
+        return responseEntries.indexOf(o);
+    }
+
+    @Override
+    public int lastIndexOf(Object o) {
+        return responseEntries.lastIndexOf(o);
+    }
+
+    @Override
+    public ListIterator<ResponseEntry> listIterator() {
+        return responseEntries.listIterator();
+    }
+
+    @Override
+    public ListIterator<ResponseEntry> listIterator(int index) {
+        return responseEntries.listIterator(index);
+    }
+
+    @Override
+    public List<ResponseEntry> subList(int fromIndex, int toIndex) {
+        return responseEntries.subList(fromIndex, toIndex);
+    }
+    // endregion
 }

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/message/UserAuthInfoRequestMessage.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/message/UserAuthInfoRequestMessage.java
@@ -16,8 +16,6 @@ import de.rub.nds.sshattacker.core.protocol.authentication.handler.UserAuthInfoR
 import de.rub.nds.sshattacker.core.protocol.common.SshMessage;
 import de.rub.nds.sshattacker.core.state.SshContext;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.List;
 
 public class UserAuthInfoRequestMessage extends SshMessage<UserAuthInfoRequestMessage> {
 
@@ -28,8 +26,8 @@ public class UserAuthInfoRequestMessage extends SshMessage<UserAuthInfoRequestMe
     private ModifiableString instruction;
     private ModifiableInteger languageTagLength;
     private ModifiableString languageTag;
-    private ModifiableInteger numPrompts;
-    private List<AuthenticationPrompt> prompts = new ArrayList<AuthenticationPrompt>();
+    private ModifiableInteger promptEntryCount;
+    private AuthenticationPrompt prompt = new AuthenticationPrompt();
 
     public UserAuthInfoRequestMessage() {
         super();
@@ -152,24 +150,25 @@ public class UserAuthInfoRequestMessage extends SshMessage<UserAuthInfoRequestMe
         this.languageTag = ModifiableVariableFactory.safelySetValue(this.languageTag, languageTag);
     }
 
-    public ModifiableInteger getNumPrompts() {
-        return numPrompts;
+    public ModifiableInteger getPromptEntryCount() {
+        return promptEntryCount;
     }
 
-    public void setNumPrompts(ModifiableInteger numPrompts) {
-        this.numPrompts = numPrompts;
+    public void setPromptEntryCount(ModifiableInteger promptEntryCount) {
+        this.promptEntryCount = promptEntryCount;
     }
 
-    public void setNumPrompts(int numPrompts) {
-        this.numPrompts = ModifiableVariableFactory.safelySetValue(this.numPrompts, numPrompts);
+    public void setPromptEntryCount(int promptEntryCount) {
+        this.promptEntryCount =
+                ModifiableVariableFactory.safelySetValue(this.promptEntryCount, promptEntryCount);
     }
 
-    public List<AuthenticationPrompt> getPrompts() {
-        return prompts;
+    public AuthenticationPrompt getPrompt() {
+        return prompt;
     }
 
-    public void setPrompts(List<AuthenticationPrompt> prompts) {
-        this.prompts = prompts;
+    public void setPrompt(AuthenticationPrompt prompt) {
+        this.prompt = prompt;
     }
 
     @Override

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/message/UserAuthInfoResponseMessage.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/message/UserAuthInfoResponseMessage.java
@@ -14,38 +14,37 @@ import de.rub.nds.sshattacker.core.protocol.authentication.AuthenticationRespons
 import de.rub.nds.sshattacker.core.protocol.authentication.handler.UserAuthInfoResponseMessageHandler;
 import de.rub.nds.sshattacker.core.protocol.common.SshMessage;
 import de.rub.nds.sshattacker.core.state.SshContext;
-import java.util.ArrayList;
-import java.util.List;
 
 public class UserAuthInfoResponseMessage extends SshMessage<UserAuthInfoResponseMessage> {
 
     public static final MessageIdConstant ID = MessageIdConstant.SSH_MSG_USERAUTH_INFO_RESPONSE;
-    private ModifiableInteger numResponses;
-    private List<AuthenticationResponse> responses = new ArrayList<AuthenticationResponse>();
+    private ModifiableInteger responseEntryCount;
+    private AuthenticationResponse response = new AuthenticationResponse();
 
     public UserAuthInfoResponseMessage() {
         super();
     }
 
-    public ModifiableInteger getNumResponses() {
-        return numResponses;
+    public ModifiableInteger getResponseEntryCount() {
+        return responseEntryCount;
     }
 
-    public void setNumResponses(ModifiableInteger numResponses) {
-        this.numResponses = numResponses;
+    public void setResponseEntryCount(ModifiableInteger responseEntryCount) {
+        this.responseEntryCount = responseEntryCount;
     }
 
-    public void setNumResponses(int numResponses) {
-        this.numResponses =
-                ModifiableVariableFactory.safelySetValue(this.numResponses, numResponses);
+    public void setResponseEntryCount(int responseEntryCount) {
+        this.responseEntryCount =
+                ModifiableVariableFactory.safelySetValue(
+                        this.responseEntryCount, responseEntryCount);
     }
 
-    public List<AuthenticationResponse> getResponses() {
-        return responses;
+    public AuthenticationResponse getResponse() {
+        return response;
     }
 
-    public void setResponses(List<AuthenticationResponse> responses) {
-        this.responses = responses;
+    public void setResponse(AuthenticationResponse response) {
+        this.response = response;
     }
 
     @Override

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/parser/UserAuthInfoRequestMessageParser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/parser/UserAuthInfoRequestMessageParser.java
@@ -53,24 +53,24 @@ public class UserAuthInfoRequestMessageParser extends SshMessageParser<UserAuthI
         LOGGER.debug("Language tag: " + message.getLanguageTag().getValue());
     }
 
-    private void parsePrompts() {
-        message.setNumPrompts(parseIntField(DataFormatConstants.UINT32_SIZE));
-        LOGGER.debug("Number of prompts: " + message.getNumPrompts().getValue());
+    private void parsePromptEntries() {
+        message.setPromptEntryCount(parseIntField(DataFormatConstants.UINT32_SIZE));
+        LOGGER.debug("Number of prompt entries: " + message.getPromptEntryCount().getValue());
 
-        for (int i = 0; i < message.getNumPrompts().getValue(); i++) {
-            AuthenticationPrompt temp = new AuthenticationPrompt();
-            temp.setPromptLength(parseIntField(DataFormatConstants.STRING_SIZE_LENGTH));
-            LOGGER.debug("Prompt[" + i + "] length: " + temp.getPromptLength().getValue());
-            temp.setPrompt(parseByteString(temp.getPromptLength().getValue()));
-            LOGGER.debug("Prompt[" + i + "]: " + temp.getPrompt().getValue());
-            temp.setEcho(parseByteField(1));
+        for (int i = 0; i < message.getPromptEntryCount().getValue(); i++) {
+            AuthenticationPrompt.PromptEntry entry = new AuthenticationPrompt.PromptEntry();
+            entry.setPromptLength(parseIntField(DataFormatConstants.STRING_SIZE_LENGTH));
+            LOGGER.debug("Prompt entry [" + i + "] length: " + entry.getPromptLength().getValue());
+            entry.setPrompt(parseByteString(entry.getPromptLength().getValue()));
+            LOGGER.debug("Prompt entry [" + i + "]: " + entry.getPrompt().getValue());
+            entry.setEcho(parseByteField(1));
             LOGGER.debug(
-                    "Prompt["
+                    "Prompt entry ["
                             + i
                             + "] wants echo:"
-                            + Converter.byteToBoolean(temp.getEcho().getValue()));
+                            + Converter.byteToBoolean(entry.getEcho().getValue()));
 
-            message.getPrompts().add(temp);
+            message.getPrompt().add(entry);
         }
     }
 
@@ -79,6 +79,6 @@ public class UserAuthInfoRequestMessageParser extends SshMessageParser<UserAuthI
         parseUserName();
         parseInstruction();
         parseLanguageTag();
-        parsePrompts();
+        parsePromptEntries();
     }
 }

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/parser/UserAuthInfoResponseMessageParser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/parser/UserAuthInfoResponseMessageParser.java
@@ -32,21 +32,22 @@ public class UserAuthInfoResponseMessageParser
         return new UserAuthInfoResponseMessage();
     }
 
-    private void parseResponses() {
-        message.setNumResponses(parseIntField(DataFormatConstants.UINT32_SIZE));
-        LOGGER.debug("Number of responses: " + message.getNumResponses().getValue());
-        for (int i = 0; i < message.getNumResponses().getValue(); i++) {
-            AuthenticationResponse temp = new AuthenticationResponse();
-            temp.setResponseLength(parseIntField(DataFormatConstants.STRING_SIZE_LENGTH));
-            LOGGER.debug("Response[" + i + "] length: " + temp.getResponseLength().getValue());
-            temp.setResponse(parseByteString(temp.getResponseLength().getValue()));
-            LOGGER.debug("Response[" + i + "]: " + temp.getResponse().getValue());
-            message.getResponses().add(temp);
+    private void parseResponseEntries() {
+        message.setResponseEntryCount(parseIntField(DataFormatConstants.UINT32_SIZE));
+        LOGGER.debug("Number of response entries: " + message.getResponseEntryCount().getValue());
+        for (int i = 0; i < message.getResponseEntryCount().getValue(); i++) {
+            AuthenticationResponse.ResponseEntry entry = new AuthenticationResponse.ResponseEntry();
+            entry.setResponseLength(parseIntField(DataFormatConstants.STRING_SIZE_LENGTH));
+            LOGGER.debug(
+                    "Response entry [" + i + "] length: " + entry.getResponseLength().getValue());
+            entry.setResponse(parseByteString(entry.getResponseLength().getValue()));
+            LOGGER.debug("Response entry [" + i + "]: " + entry.getResponse().getValue());
+            message.getResponse().add(entry);
         }
     }
 
     @Override
     protected void parseMessageSpecificContents() {
-        parseResponses();
+        parseResponseEntries();
     }
 }

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/preparator/UserAuthInfoRequestMessagePreperator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/preparator/UserAuthInfoRequestMessagePreperator.java
@@ -24,6 +24,6 @@ public class UserAuthInfoRequestMessagePreperator
         getObject().setUserName("", true);
         getObject().setInstruction("", true);
         getObject().setLanguageTag("", true);
-        getObject().setNumPrompts(0);
+        getObject().setPromptEntryCount(0);
     }
 }

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/preparator/UserAuthInfoResponseMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/preparator/UserAuthInfoResponseMessagePreparator.java
@@ -11,7 +11,6 @@ import de.rub.nds.sshattacker.core.protocol.authentication.AuthenticationRespons
 import de.rub.nds.sshattacker.core.protocol.authentication.message.UserAuthInfoResponseMessage;
 import de.rub.nds.sshattacker.core.protocol.common.SshMessagePreparator;
 import de.rub.nds.sshattacker.core.workflow.chooser.Chooser;
-import java.util.List;
 
 public class UserAuthInfoResponseMessagePreparator
         extends SshMessagePreparator<UserAuthInfoResponseMessage> {
@@ -23,17 +22,16 @@ public class UserAuthInfoResponseMessagePreparator
 
     @Override
     public void prepareMessageSpecificContents() {
-        getObject().setNumResponses(0);
+        getObject().setResponseEntryCount(0);
         for (int i = 0; i < chooser.getConfig().getPreConfiguredAuthResponses().size(); i++) {
-            List<AuthenticationResponse> authenticationResponseList =
-                    (List<AuthenticationResponse>)
-                            chooser.getConfig().getPreConfiguredAuthResponses().get(i);
-            if (authenticationResponseList.get(0).isExecuted()) {
+            AuthenticationResponse authenticationResponse =
+                    chooser.getConfig().getPreConfiguredAuthResponses().get(i);
+            if (authenticationResponse.get(0).isExecuted()) {
                 i++;
             } else {
-                getObject().setResponses(authenticationResponseList);
-                getObject().setNumResponses(authenticationResponseList.size());
-                authenticationResponseList.get(0).setExecuted(true);
+                getObject().setResponse(authenticationResponse);
+                getObject().setResponseEntryCount(authenticationResponse.size());
+                authenticationResponse.get(0).setExecuted(true);
                 break;
             }
         }

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/serializer/UserAuthInfoRequestMessageSerializer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/serializer/UserAuthInfoRequestMessageSerializer.java
@@ -47,22 +47,22 @@ public class UserAuthInfoRequestMessageSerializer
         appendString(message.getLanguageTag().getValue());
     }
 
-    private void serializePrompts() {
-        LOGGER.debug("Number of promts: " + message.getNumPrompts().getValue());
-        appendInt(message.getNumPrompts().getValue(), DataFormatConstants.UINT32_SIZE);
+    private void serializePrompt() {
+        LOGGER.debug("Number of prompt entries: " + message.getPromptEntryCount().getValue());
+        appendInt(message.getPromptEntryCount().getValue(), DataFormatConstants.UINT32_SIZE);
 
-        for (int i = 0; i < message.getNumPrompts().getValue(); i++) {
-            AuthenticationPrompt temp = message.getPrompts().get(i);
-            LOGGER.debug("Prompt[" + i + "] length: " + temp.getPromptLength().getValue());
-            appendInt(temp.getPromptLength().getValue(), DataFormatConstants.STRING_SIZE_LENGTH);
-            LOGGER.debug("Prompt[" + i + "] : " + temp.getPrompt());
-            appendString(temp.getPrompt().getValue());
+        for (int i = 0; i < message.getPromptEntryCount().getValue(); i++) {
+            AuthenticationPrompt.PromptEntry entry = message.getPrompt().get(i);
+            LOGGER.debug("Prompt entry [" + i + "] length: " + entry.getPromptLength().getValue());
+            appendInt(entry.getPromptLength().getValue(), DataFormatConstants.STRING_SIZE_LENGTH);
+            LOGGER.debug("Prompt entry [" + i + "] : " + entry.getPrompt());
+            appendString(entry.getPrompt().getValue());
             LOGGER.debug(
-                    "Prompt["
+                    "Prompt entry ["
                             + i
                             + "] wants echo: "
-                            + Converter.byteToBoolean(temp.getEcho().getValue()));
-            appendByte(temp.getEcho().getValue());
+                            + Converter.byteToBoolean(entry.getEcho().getValue()));
+            appendByte(entry.getEcho().getValue());
         }
     }
 
@@ -71,6 +71,6 @@ public class UserAuthInfoRequestMessageSerializer
         serializeUserName();
         serializeInstruction();
         serializeLanguageTag();
-        serializePrompts();
+        serializePrompt();
     }
 }

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/serializer/UserAuthInfoResponseMessageSerializer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/authentication/serializer/UserAuthInfoResponseMessageSerializer.java
@@ -23,21 +23,22 @@ public class UserAuthInfoResponseMessageSerializer
         super(message);
     }
 
-    private void serializeResponses() {
-        LOGGER.debug("Number of responses: " + message.getNumResponses().getValue());
-        appendInt(message.getNumResponses().getValue(), DataFormatConstants.UINT32_SIZE);
+    private void serializeResponse() {
+        LOGGER.debug("Number of response entries: " + message.getResponseEntryCount().getValue());
+        appendInt(message.getResponseEntryCount().getValue(), DataFormatConstants.UINT32_SIZE);
 
-        for (int i = 0; i < message.getNumResponses().getValue(); i++) {
-            AuthenticationResponse temp = message.getResponses().get(i);
-            LOGGER.debug("Response[" + i + "] length: " + temp.getResponseLength().getValue());
-            appendInt(temp.getResponseLength().getValue(), DataFormatConstants.UINT32_SIZE);
-            LOGGER.debug("Response[" + i + "]: " + temp.getResponse().getValue());
-            appendString(temp.getResponse().getValue(), StandardCharsets.UTF_8);
+        for (int i = 0; i < message.getResponseEntryCount().getValue(); i++) {
+            AuthenticationResponse.ResponseEntry entry = message.getResponse().get(i);
+            LOGGER.debug(
+                    "Response entry [" + i + "] length: " + entry.getResponseLength().getValue());
+            appendInt(entry.getResponseLength().getValue(), DataFormatConstants.UINT32_SIZE);
+            LOGGER.debug("Response entry [" + i + "]: " + entry.getResponse().getValue());
+            appendString(entry.getResponse().getValue(), StandardCharsets.UTF_8);
         }
     }
 
     @Override
     public void serializeMessageSpecificContents() {
-        serializeResponses();
+        serializeResponse();
     }
 }


### PR DESCRIPTION
Fixes #116 
---
The issue was caused by the use of a nested list for pre-configured authentication responses in Config. JAXB is not able to properly handle these. I redefined the term authentication response to be the entirety of all authentication response entries (previously called authentication response) send within a single message. This removes the nested construction since pre-configured authentication responses are now a simple list which can be handled by JAXB. To ease access to the individual authentication response entries, the authentication response class implements the `List` interface. All methods are backed by a simple `ArrayList` holding the actual entries. As a result, the API for accessing individual entries has not been altered in the way that additional function calls would be necessary.

The definition and implementation of authentication prompts (basically the client -> server variant of authentication responses) have been altered in the same way.