### PR TITLE
ci: Minor fixes and enhancements

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,6 +46,13 @@ pipeline {
             }
         }
         stage('Code Analysis') {
+            when {
+                anyOf {
+                    branch 'main'
+                    tag 'v*'
+                    changeRequest()
+                }
+            }
             options {
                 timeout(activity: true, time: 120, unit: 'SECONDS')
             }
@@ -61,6 +68,13 @@ pipeline {
             }
         }
         stage('Unit Tests') {
+            when {
+                anyOf {
+                    branch 'main'
+                    tag 'v*'
+                    changeRequest()
+                }
+            }
             options {
                 timeout(activity: true, time: 120, unit: 'SECONDS')
             }
@@ -76,6 +90,13 @@ pipeline {
             }
         }
         stage('Integration Tests') {
+            when {
+                anyOf {
+                    branch 'main'
+                    tag 'v*'
+                    changeRequest()
+                }
+            }
             options {
                 timeout(activity: true, time: 120, unit: 'SECONDS')
             }


### PR DESCRIPTION
- Do not run full pipeline on every feature branch commit. Instead, only check for formatting issues and build the project once. Unit tests, integration tests and static code analysis steps are now exclusive to PRs, main branch commits, and release tags.
- If there's already a build running on an outdated commit (i. e. someone pushed to a branch with open PR while checks are still running, abort this build before invoking a new one).
- Move format check back to its own stage. This avoids calling spotless:apply before spotless:check, effectively rendering the latter useless.