### PR TITLE
refactor(core): Use `Language` type instead of `String` for languages

### DIFF
--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/config/Config.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/config/Config.java
@@ -163,22 +163,22 @@ public class Config implements Serializable {
     /** List of languages (client to server) supported by the client */
     @XmlElement(name = "clientSupportedLanguageClientToServer")
     @XmlElementWrapper
-    private List<String> clientSupportedLanguagesClientToServer;
+    private List<Language> clientSupportedLanguagesClientToServer;
 
     /** List of languages (server to client) supported by the client */
     @XmlElement(name = "clientSupportedLanguageServerToClient")
     @XmlElementWrapper
-    private List<String> clientSupportedLanguagesServerToClient;
+    private List<Language> clientSupportedLanguagesServerToClient;
 
     /** List of languages (client to server) supported by the server */
     @XmlElement(name = "serverSupportedLanguageServerToClient")
     @XmlElementWrapper
-    private List<String> serverSupportedLanguagesServerToClient;
+    private List<Language> serverSupportedLanguagesServerToClient;
 
     /** List of languages (server to client) supported by the server */
     @XmlElement(name = "serverSupportedLanguageClientToServer")
     @XmlElementWrapper
-    private List<String> serverSupportedLanguagesClientToServer;
+    private List<Language> serverSupportedLanguagesClientToServer;
 
     /**
      * A boolean flag used to indicate that a guessed key exchange paket will be sent by the client
@@ -1001,19 +1001,19 @@ public class Config implements Serializable {
         return serverSupportedCompressionMethodsClientToServer;
     }
 
-    public List<String> getClientSupportedLanguagesClientToServer() {
+    public List<Language> getClientSupportedLanguagesClientToServer() {
         return clientSupportedLanguagesClientToServer;
     }
 
-    public List<String> getClientSupportedLanguagesServerToClient() {
+    public List<Language> getClientSupportedLanguagesServerToClient() {
         return clientSupportedLanguagesServerToClient;
     }
 
-    public List<String> getServerSupportedLanguagesServerToClient() {
+    public List<Language> getServerSupportedLanguagesServerToClient() {
         return serverSupportedLanguagesServerToClient;
     }
 
-    public List<String> getServerSupportedLanguagesClientToServer() {
+    public List<Language> getServerSupportedLanguagesClientToServer() {
         return serverSupportedLanguagesClientToServer;
     }
 
@@ -1132,22 +1132,22 @@ public class Config implements Serializable {
     }
 
     public void setClientSupportedLanguagesClientToServer(
-            List<String> clientSupportedLanguagesClientToServer) {
+            List<Language> clientSupportedLanguagesClientToServer) {
         this.clientSupportedLanguagesClientToServer = clientSupportedLanguagesClientToServer;
     }
 
     public void setClientSupportedLanguagesServerToClient(
-            List<String> clientSupportedLanguagesServerToClient) {
+            List<Language> clientSupportedLanguagesServerToClient) {
         this.clientSupportedLanguagesServerToClient = clientSupportedLanguagesServerToClient;
     }
 
     public void setServerSupportedLanguagesServerToClient(
-            List<String> serverSupportedLanguagesServerToClient) {
+            List<Language> serverSupportedLanguagesServerToClient) {
         this.serverSupportedLanguagesServerToClient = serverSupportedLanguagesServerToClient;
     }
 
     public void setServerSupportedLanguagesClientToServer(
-            List<String> serverSupportedLanguagesClientToServer) {
+            List<Language> serverSupportedLanguagesClientToServer) {
         this.serverSupportedLanguagesClientToServer = serverSupportedLanguagesClientToServer;
     }
 

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/handler/KeyExchangeInitMessageHandler.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/handler/KeyExchangeInitMessageHandler.java
@@ -16,7 +16,6 @@ import de.rub.nds.sshattacker.core.protocol.transport.serializer.KeyExchangeInit
 import de.rub.nds.sshattacker.core.protocol.util.AlgorithmPicker;
 import de.rub.nds.sshattacker.core.state.SshContext;
 import de.rub.nds.sshattacker.core.util.Converter;
-import java.util.Arrays;
 
 public class KeyExchangeInitMessageHandler extends SshMessageHandler<KeyExchangeInitMessage> {
 
@@ -65,15 +64,11 @@ public class KeyExchangeInitMessageHandler extends SshMessageHandler<KeyExchange
                             message.getCompressionMethodsServerToClient().getValue(),
                             CompressionMethod.class));
             context.setServerSupportedLanguagesClientToServer(
-                    Arrays.asList(
-                            message.getLanguagesClientToServer()
-                                    .getValue()
-                                    .split("" + CharConstants.ALGORITHM_SEPARATOR)));
+                    Converter.nameListToEnumValues(
+                            message.getLanguagesClientToServer().getValue(), Language.class));
             context.setServerSupportedLanguagesServerToClient(
-                    Arrays.asList(
-                            message.getLanguagesServerToClient()
-                                    .getValue()
-                                    .split("" + CharConstants.ALGORITHM_SEPARATOR)));
+                    Converter.nameListToEnumValues(
+                            message.getLanguagesServerToClient().getValue(), Language.class));
             context.setServerReserved(message.getReserved().getValue());
 
             context.getExchangeHashInputHolder().setServerKeyExchangeInit(message);
@@ -112,15 +107,11 @@ public class KeyExchangeInitMessageHandler extends SshMessageHandler<KeyExchange
                             message.getCompressionMethodsServerToClient().getValue(),
                             CompressionMethod.class));
             context.setClientSupportedLanguagesClientToServer(
-                    Arrays.asList(
-                            message.getLanguagesClientToServer()
-                                    .getValue()
-                                    .split("" + CharConstants.ALGORITHM_SEPARATOR)));
+                    Converter.nameListToEnumValues(
+                            message.getLanguagesClientToServer().getValue(), Language.class));
             context.setClientSupportedLanguagesServerToClient(
-                    Arrays.asList(
-                            message.getLanguagesServerToClient()
-                                    .getValue()
-                                    .split("" + CharConstants.ALGORITHM_SEPARATOR)));
+                    Converter.nameListToEnumValues(
+                            message.getLanguagesServerToClient().getValue(), Language.class));
             context.setClientReserved(message.getReserved().getValue());
 
             context.getExchangeHashInputHolder().setClientKeyExchangeInit(message);

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/state/SshContext.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/state/SshContext.java
@@ -131,13 +131,13 @@ public class SshContext {
     /** List of compression algorithms (server to client) supported by the server */
     private List<CompressionMethod> serverSupportedCompressionMethodsServerToClient;
     /** List of languages (client to server) supported by the client */
-    private List<String> clientSupportedLanguagesClientToServer;
+    private List<Language> clientSupportedLanguagesClientToServer;
     /** List of languages (server to client) supported by the client */
-    private List<String> clientSupportedLanguagesServerToClient;
+    private List<Language> clientSupportedLanguagesServerToClient;
     /** List of languages (client to server) supported by the server */
-    private List<String> serverSupportedLanguagesClientToServer;
+    private List<Language> serverSupportedLanguagesClientToServer;
     /** List of languages (server to client) supported by the server */
-    private List<String> serverSupportedLanguagesServerToClient;
+    private List<Language> serverSupportedLanguagesServerToClient;
     /**
      * A boolean flag used to indicate that a guessed key exchange paket will be sent by the client
      */
@@ -527,19 +527,19 @@ public class SshContext {
         return Optional.ofNullable(serverSupportedCompressionMethodsClientToServer);
     }
 
-    public Optional<List<String>> getClientSupportedLanguagesClientToServer() {
+    public Optional<List<Language>> getClientSupportedLanguagesClientToServer() {
         return Optional.ofNullable(clientSupportedLanguagesClientToServer);
     }
 
-    public Optional<List<String>> getClientSupportedLanguagesServerToClient() {
+    public Optional<List<Language>> getClientSupportedLanguagesServerToClient() {
         return Optional.ofNullable(clientSupportedLanguagesServerToClient);
     }
 
-    public Optional<List<String>> getServerSupportedLanguagesServerToClient() {
+    public Optional<List<Language>> getServerSupportedLanguagesServerToClient() {
         return Optional.ofNullable(serverSupportedLanguagesServerToClient);
     }
 
-    public Optional<List<String>> getServerSupportedLanguagesClientToServer() {
+    public Optional<List<Language>> getServerSupportedLanguagesClientToServer() {
         return Optional.ofNullable(serverSupportedLanguagesClientToServer);
     }
 
@@ -662,22 +662,22 @@ public class SshContext {
     }
 
     public void setClientSupportedLanguagesClientToServer(
-            List<String> clientSupportedLanguagesClientToServer) {
+            List<Language> clientSupportedLanguagesClientToServer) {
         this.clientSupportedLanguagesClientToServer = clientSupportedLanguagesClientToServer;
     }
 
     public void setClientSupportedLanguagesServerToClient(
-            List<String> clientSupportedLanguagesServerToClient) {
+            List<Language> clientSupportedLanguagesServerToClient) {
         this.clientSupportedLanguagesServerToClient = clientSupportedLanguagesServerToClient;
     }
 
     public void setServerSupportedLanguagesServerToClient(
-            List<String> serverSupportedLanguagesServerToClient) {
+            List<Language> serverSupportedLanguagesServerToClient) {
         this.serverSupportedLanguagesServerToClient = serverSupportedLanguagesServerToClient;
     }
 
     public void setServerSupportedLanguagesClientToServer(
-            List<String> serverSupportedLanguagesClientToServer) {
+            List<Language> serverSupportedLanguagesClientToServer) {
         this.serverSupportedLanguagesClientToServer = serverSupportedLanguagesClientToServer;
     }
 

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/chooser/Chooser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/chooser/Chooser.java
@@ -94,13 +94,13 @@ public abstract class Chooser {
 
     public abstract List<CompressionMethod> getServerSupportedCompressionMethodsClientToServer();
 
-    public abstract List<String> getClientSupportedLanguagesClientToServer();
+    public abstract List<Language> getClientSupportedLanguagesClientToServer();
 
-    public abstract List<String> getClientSupportedLanguagesServerToClient();
+    public abstract List<Language> getClientSupportedLanguagesServerToClient();
 
-    public abstract List<String> getServerSupportedLanguagesServerToClient();
+    public abstract List<Language> getServerSupportedLanguagesServerToClient();
 
-    public abstract List<String> getServerSupportedLanguagesClientToServer();
+    public abstract List<Language> getServerSupportedLanguagesClientToServer();
 
     public abstract boolean getClientFirstKeyExchangePacketFollows();
 

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/chooser/DefaultChooser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/chooser/DefaultChooser.java
@@ -377,7 +377,7 @@ public class DefaultChooser extends Chooser {
      * @return A list of languages for client to server communication supported by the client
      */
     @Override
-    public List<String> getClientSupportedLanguagesClientToServer() {
+    public List<Language> getClientSupportedLanguagesClientToServer() {
         return context.getClientSupportedLanguagesClientToServer()
                 .orElse(config.getClientSupportedLanguagesClientToServer());
     }
@@ -391,7 +391,7 @@ public class DefaultChooser extends Chooser {
      * @return A list of languages for server to client communication supported by the client
      */
     @Override
-    public List<String> getClientSupportedLanguagesServerToClient() {
+    public List<Language> getClientSupportedLanguagesServerToClient() {
         return context.getClientSupportedLanguagesServerToClient()
                 .orElse(config.getClientSupportedLanguagesServerToClient());
     }
@@ -405,7 +405,7 @@ public class DefaultChooser extends Chooser {
      * @return A list of languages for server to client communication supported by the server
      */
     @Override
-    public List<String> getServerSupportedLanguagesServerToClient() {
+    public List<Language> getServerSupportedLanguagesServerToClient() {
         return context.getServerSupportedLanguagesServerToClient()
                 .orElse(config.getServerSupportedLanguagesServerToClient());
     }
@@ -419,7 +419,7 @@ public class DefaultChooser extends Chooser {
      * @return A list of languages for client to server communication supported by the server
      */
     @Override
-    public List<String> getServerSupportedLanguagesClientToServer() {
+    public List<Language> getServerSupportedLanguagesClientToServer() {
         return context.getServerSupportedLanguagesClientToServer()
                 .orElse(config.getServerSupportedLanguagesClientToServer());
     }


### PR DESCRIPTION
All similar methods use a dedicated type instead of `String`. A `Language` type already exists, and it's confusing that it's not used.