### PR TITLE
release: v1.0.0

### DIFF
--- a/Attacks/pom.xml
+++ b/Attacks/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>de.rub.nds.ssh.attacker</groupId>
         <artifactId>ssh-attacker</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.1-SNAPSHOT</version>
     </parent>
     <artifactId>attacks</artifactId>
 
@@ -13,7 +13,7 @@
     <scm>
         <connection>scm:git:https://github.com/tls-attacker/SSH-Attacker.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/tls-attacker/SSH-Attacker.git</developerConnection>
-        <tag>v1.0.0</tag>
+        <tag>HEAD</tag>
         <url>https://github.com/tls-attacker/SSH-Attacker</url>
     </scm>
 

--- a/SSH-Client/pom.xml
+++ b/SSH-Client/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>de.rub.nds.ssh.attacker</groupId>
         <artifactId>ssh-attacker</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.1-SNAPSHOT</version>
     </parent>
     <artifactId>ssh-client</artifactId>
 
@@ -13,7 +13,7 @@
     <scm>
         <connection>scm:git:https://github.com/tls-attacker/SSH-Attacker.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/tls-attacker/SSH-Attacker.git</developerConnection>
-        <tag>v1.0.0</tag>
+        <tag>HEAD</tag>
         <url>https://github.com/tls-attacker/SSH-Attacker</url>
     </scm>
 

--- a/SSH-Core/pom.xml
+++ b/SSH-Core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>de.rub.nds.ssh.attacker</groupId>
         <artifactId>ssh-attacker</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.1-SNAPSHOT</version>
     </parent>
     <artifactId>ssh-core</artifactId>
 
@@ -13,7 +13,7 @@
     <scm>
         <connection>scm:git:https://github.com/tls-attacker/SSH-Attacker.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/tls-attacker/SSH-Attacker.git</developerConnection>
-        <tag>v1.0.0</tag>
+        <tag>HEAD</tag>
         <url>https://github.com/tls-attacker/SSH-Attacker</url>
     </scm>
 

--- a/SSH-Mitm/pom.xml
+++ b/SSH-Mitm/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>de.rub.nds.ssh.attacker</groupId>
         <artifactId>ssh-attacker</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.1-SNAPSHOT</version>
     </parent>
     <artifactId>ssh-mitm</artifactId>
 
@@ -13,7 +13,7 @@
     <scm>
         <connection>scm:git:https://github.com/tls-attacker/SSH-Attacker.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/tls-attacker/SSH-Attacker.git</developerConnection>
-        <tag>v1.0.0</tag>
+        <tag>HEAD</tag>
         <url>https://github.com/tls-attacker/SSH-Attacker</url>
     </scm>
 

--- a/SSH-Server/pom.xml
+++ b/SSH-Server/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>de.rub.nds.ssh.attacker</groupId>
         <artifactId>ssh-attacker</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.1-SNAPSHOT</version>
     </parent>
     <artifactId>ssh-server</artifactId>
 
@@ -13,7 +13,7 @@
     <scm>
         <connection>scm:git:https://github.com/tls-attacker/SSH-Attacker.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/tls-attacker/SSH-Attacker.git</developerConnection>
-        <tag>v1.0.0</tag>
+        <tag>HEAD</tag>
         <url>https://github.com/tls-attacker/SSH-Attacker</url>
     </scm>
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>de.rub.nds.ssh.attacker</groupId>
     <artifactId>ssh-attacker</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>SSH-Attacker</name>
@@ -55,7 +55,7 @@
     <scm>
         <connection>scm:git:https://github.com/tls-attacker/SSH-Attacker.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/tls-attacker/SSH-Attacker.git</developerConnection>
-        <tag>v1.0.0</tag>
+        <tag>HEAD</tag>
         <url>https://github.com/tls-attacker/SSH-Attacker</url>
     </scm>
 


### PR DESCRIPTION
Our first "stable" internal release of SSH-Attacker which is now used by SSH-Scanner.