### PR TITLE
feat: Introduce forcePacketCipherChange flag

### DIFF
--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/config/Config.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/config/Config.java
@@ -237,6 +237,14 @@ public class Config implements Serializable {
      */
     private Boolean enableEncryptionOnNewKeysMessage = true;
     /**
+     * If set to false, the packet cipher will only be changed in case of algorithm or key material
+     * change during the SSH_MSG_NEWKEYS handler. This can be useful if one tries sending NEWKEYS
+     * without a proper key exchange beforehand and would like to be able to decrypt the servers'
+     * response encrypted under the old cipher state. Will take no effect if {@link
+     * #enableEncryptionOnNewKeysMessage} is set to false.
+     */
+    private Boolean forcePacketCipherChange = false;
+    /**
      * If enforceSettings is true, the algorithms are expected to be already set in the SshContext,
      * when picking the algorithms
      */
@@ -1223,6 +1231,10 @@ public class Config implements Serializable {
         return enableEncryptionOnNewKeysMessage;
     }
 
+    public Boolean getForcePacketCipherChange() {
+        return forcePacketCipherChange;
+    }
+
     public Boolean getEnforceSettings() {
         return enforceSettings;
     }
@@ -1272,6 +1284,10 @@ public class Config implements Serializable {
 
     public void setEnableEncryptionOnNewKeysMessage(Boolean enableEncryptionOnNewKeysMessage) {
         this.enableEncryptionOnNewKeysMessage = enableEncryptionOnNewKeysMessage;
+    }
+
+    public void setForcePacketCipherChange(Boolean forcePacketCipherChange) {
+        this.forcePacketCipherChange = forcePacketCipherChange;
     }
 
     public void setEnforceSettings(Boolean enforceSettings) {

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/cipher/keys/KeySet.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/cipher/keys/KeySet.java
@@ -12,6 +12,7 @@ import de.rub.nds.tlsattacker.transport.ConnectionEndType;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlRootElement;
+import java.util.Arrays;
 
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.FIELD)
@@ -141,5 +142,29 @@ public class KeySet {
                 + "\n"
                 + "Integrity key (server to client): "
                 + ArrayConverter.bytesToRawHexString(serverWriteIntegrityKey);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        KeySet keySet = (KeySet) o;
+        return Arrays.equals(clientWriteInitialIv, keySet.clientWriteInitialIv)
+                && Arrays.equals(serverWriteInitialIv, keySet.serverWriteInitialIv)
+                && Arrays.equals(clientWriteEncryptionKey, keySet.clientWriteEncryptionKey)
+                && Arrays.equals(serverWriteEncryptionKey, keySet.serverWriteEncryptionKey)
+                && Arrays.equals(clientWriteIntegrityKey, keySet.clientWriteIntegrityKey)
+                && Arrays.equals(serverWriteIntegrityKey, keySet.serverWriteIntegrityKey);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Arrays.hashCode(clientWriteInitialIv);
+        result = 31 * result + Arrays.hashCode(serverWriteInitialIv);
+        result = 31 * result + Arrays.hashCode(clientWriteEncryptionKey);
+        result = 31 * result + Arrays.hashCode(serverWriteEncryptionKey);
+        result = 31 * result + Arrays.hashCode(clientWriteIntegrityKey);
+        result = 31 * result + Arrays.hashCode(serverWriteIntegrityKey);
+        return result;
     }
 }

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/handler/NewKeysMessageHandler.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/handler/NewKeysMessageHandler.java
@@ -7,10 +7,7 @@
  */
 package de.rub.nds.sshattacker.core.protocol.transport.handler;
 
-import de.rub.nds.sshattacker.core.constants.CipherMode;
-import de.rub.nds.sshattacker.core.constants.CompressionMethod;
-import de.rub.nds.sshattacker.core.constants.EncryptionAlgorithm;
-import de.rub.nds.sshattacker.core.constants.MacAlgorithm;
+import de.rub.nds.sshattacker.core.constants.*;
 import de.rub.nds.sshattacker.core.packet.cipher.PacketCipher;
 import de.rub.nds.sshattacker.core.packet.cipher.PacketCipherFactory;
 import de.rub.nds.sshattacker.core.packet.cipher.keys.KeySet;
@@ -53,18 +50,51 @@ public class NewKeysMessageHandler extends SshMessageHandler<NewKeysMessage>
     private void adjustEncryptionForDirection(boolean receive) {
         Chooser chooser = context.getChooser();
         Optional<KeySet> keySet = context.getKeySet();
-        EncryptionAlgorithm encryptionAlgorithm =
-                receive
-                        ? chooser.getReceiveEncryptionAlgorithm()
-                        : chooser.getSendEncryptionAlgorithm();
-        MacAlgorithm macAlgorithm =
-                receive ? chooser.getReceiveMacAlgorithm() : chooser.getSendMacAlgorithm();
         if (keySet.isEmpty()) {
             LOGGER.warn(
                     "Unable to update the active {} cipher after handling a new keys message because key set is missing - workflow will continue with old cipher",
                     receive ? "decryption" : "encryption");
             return;
         }
+
+        EncryptionAlgorithm encryptionAlgorithm;
+        MacAlgorithm macAlgorithm;
+        if (receive) {
+            encryptionAlgorithm = chooser.getReceiveEncryptionAlgorithm();
+            macAlgorithm = chooser.getReceiveMacAlgorithm();
+            KeySet activeKeySet = context.getPacketLayer().getDecryptorCipher().getKeySet();
+            EncryptionAlgorithm activeEncryptionAlgorithm =
+                    context.getPacketLayer().getDecryptorCipher().getEncryptionAlgorithm();
+            MacAlgorithm activeMacAlgorithm =
+                    context.getPacketLayer().getDecryptorCipher().getMacAlgorithm();
+            if (!context.getConfig().getForcePacketCipherChange()
+                    && activeKeySet.equals(keySet.get())
+                    && encryptionAlgorithm == activeEncryptionAlgorithm
+                    && (encryptionAlgorithm.getType() == EncryptionAlgorithmType.AEAD
+                            || macAlgorithm == activeMacAlgorithm)) {
+                LOGGER.info(
+                        "Key set and algorithms unchanged, not changing active decryption cipher - workflow will continue with old cipher");
+                return;
+            }
+        } else {
+            encryptionAlgorithm = chooser.getSendEncryptionAlgorithm();
+            macAlgorithm = chooser.getSendMacAlgorithm();
+            KeySet activeKeySet = context.getPacketLayer().getEncryptorCipher().getKeySet();
+            EncryptionAlgorithm activeEncryptionAlgorithm =
+                    context.getPacketLayer().getEncryptorCipher().getEncryptionAlgorithm();
+            MacAlgorithm activeMacAlgorithm =
+                    context.getPacketLayer().getEncryptorCipher().getMacAlgorithm();
+            if (!context.getConfig().getForcePacketCipherChange()
+                    && activeKeySet.equals(keySet.get())
+                    && encryptionAlgorithm == activeEncryptionAlgorithm
+                    && (encryptionAlgorithm.getType() == EncryptionAlgorithmType.AEAD
+                            || macAlgorithm == activeMacAlgorithm)) {
+                LOGGER.info(
+                        "Key set and algorithms unchanged, not changing active decryption cipher - workflow will continue with old cipher");
+                return;
+            }
+        }
+
         try {
             PacketCipher packetCipher =
                     PacketCipherFactory.getPacketCipher(


### PR DESCRIPTION
This PR introduces a new Config flag, namely `forcePacketCipherChange`, with a default value of false. If set to false and the automatic activation of encryption within the SSH_MSG_NEWKEYS handler is enabled, the packet cipher will only be recreated if and only if at least one of encryption algorithm, MAC algorithm, or key set differs from the active cipher state. This may be desirable in case the server responds under the old cipher state because NEWKEYS is not valid at the current state of the connection. 