### PR TITLE
fix: UMAC occasionally throws IndexOutOfBoundsException

### DIFF
--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/mac/UMac.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/mac/UMac.java
@@ -374,7 +374,7 @@ class UMac extends AbstractMac {
             y = y.add(m_[i].multiply(k_[i]));
         }
         y = y.mod(prime(36)).mod(BigInteger.ONE.shiftLeft(32));
-        byte[] Y = ArrayConverter.bigIntegerToByteArray(y);
+        byte[] Y = ArrayConverter.bigIntegerToByteArray(y, 4, true);
         for (int i = 0; i < 4; i++) {
             Y[i] = (byte) (Y[i] ^ K2[i]);
         }


### PR DESCRIPTION
The UMAC implementation occasionally throws an `IndexOutOfBoundsException`. The root cause for this is the conversion of y to a byte array Y within the L3 Hash function. According to RFC 4418 it should be:

```
Y = uint2str(y, 4)
```
where uint2str converts y to an array of bytes of length 4. However, the conversion function `bigIntegerToByteArray` may return less than 4 bytes thus resulting in the aforementioned exception.