### PR TITLE
fix: Wrongly timed NewKeys message in DH GEX workflow

### DIFF
--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/factory/WorkflowConfigurationFactory.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/factory/WorkflowConfigurationFactory.java
@@ -244,8 +244,7 @@ public class WorkflowConfigurationFactory {
                         SshActionFactory.createMessageAction(
                                 connection,
                                 ConnectionEndType.CLIENT,
-                                new DhGexKeyExchangeRequestMessage(),
-                                new NewKeysMessage()));
+                                new DhGexKeyExchangeRequestMessage()));
                 sshActions.add(
                         SshActionFactory.createMessageAction(
                                 connection,


### PR DESCRIPTION
Fixes #204