### PR TITLE
feat(core): Auto-Indent Config XML when writing to disk

### DIFF
--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/config/ConfigIO.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/config/ConfigIO.java
@@ -21,7 +21,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.nio.charset.StandardCharsets;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
@@ -63,7 +62,7 @@ public class ConfigIO {
             // Replace line separators with the system specific line separator
             String xmlText = tempStream.toString();
             xmlText = xmlText.replaceAll("\r?\n", System.lineSeparator());
-            outputStream.write(xmlText.getBytes(StandardCharsets.UTF_8));
+            outputStream.write(xmlText.getBytes());
         } catch (IOException | JAXBException | TransformerException ex) {
             throw new RuntimeException("Could not format XML", ex);
         }

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/WorkflowTraceSerializer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/WorkflowTraceSerializer.java
@@ -89,14 +89,13 @@ public class WorkflowTraceSerializer {
         try (ByteArrayOutputStream xmlOutputStream = new ByteArrayOutputStream()) {
             // circumvent the max indentation of 8 of the JAXB marshaller
             Transformer transformer = TransformerFactory.newInstance().newTransformer();
-            transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
             transformer.setOutputProperty(OutputKeys.INDENT, "yes");
             transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
             transformer.transform(
                     new JAXBSource(context, workflowTrace), new StreamResult(xmlOutputStream));
 
             String xmlText = xmlOutputStream.toString();
-            // and we modify all line separators to the system dependant line separator
+            // Replace line separators with the system specific line separator
             xmlText = xmlText.replaceAll("\r?\n", System.lineSeparator());
             outputStream.write(xmlText.getBytes());
         } catch (TransformerException E) {


### PR DESCRIPTION
Nicer formatting for exported config XMLs. This now uses the same indentation as the exported Workflow XML files.