### PR TITLE
fix: CTR decryption failure when IV starts with 0x00

### DIFF
--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/cipher/PacketMacedCipher.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/cipher/PacketMacedCipher.java
@@ -344,7 +344,8 @@ public class PacketMacedCipher extends PacketCipher {
                         ctr.mod(
                                 BigInteger.ONE.shiftLeft(
                                         Byte.SIZE * encryptionAlgorithm.getIVSize()));
-                return ArrayConverter.bigIntegerToByteArray(ctr);
+                return ArrayConverter.bigIntegerToNullPaddedByteArray(
+                        ctr, encryptionAlgorithm.getIVSize());
             default:
                 throw new UnsupportedOperationException(
                         "Unable to extract initialization vector for mode: "


### PR DESCRIPTION
Fixes #206

`extractNextIv` does not return the correct IV in CTR mode when the IV starts with a zero byte. This is due to the use of `ArrayConverter.bigIntegerToByteArray` which will strip the zero byte before returning the byte representation. As a result, the wrong IV is being stored for next cryptographic operation. This is a simple fix which will make sure that the IV returned is always padded with zero bytes to the required length.