### PR TITLE
Fix nullptr except.: Throw expected exception type

### DIFF
--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/cipher/ChaCha20Poly1305Cipher.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/crypto/cipher/ChaCha20Poly1305Cipher.java
@@ -93,6 +93,7 @@ class ChaCha20Poly1305Cipher extends AbstractCipher {
         byte[] receivedMac = Arrays.copyOfRange(encryptedData, ctLength, encryptedData.length);
         if (!Arrays.equals(calculatedMac, receivedMac)) {
             LOGGER.warn("MAC verification failed");
+            // FIXME In the context of SSH-Attacker it might be reasonable to decrypt anyway
             throw new AEADBadTagException("Poly1305 MAC verification failed");
         }
         // Decryption

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/cipher/PacketChaCha20Poly1305Cipher.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/cipher/PacketChaCha20Poly1305Cipher.java
@@ -206,6 +206,10 @@ public class PacketChaCha20Poly1305Cipher extends PacketCipher {
             LOGGER.warn(
                     "Caught an AEADBadTagException while decrypting the blob packet - returning the packet without decryption",
                     e);
+            // Trigger "none" cipher fallback to populate the compressedPayload data member
+            // FIXME
+            throw new CryptoException(
+                    "Chacha20Poly1305 bad tag (BlobPacket). CompressedPayload was not set.");
         }
     }
 

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/crypto/PacketDecryptor.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/packet/crypto/PacketDecryptor.java
@@ -42,10 +42,12 @@ public class PacketDecryptor extends AbstractPacketDecryptor {
             packet.setSequenceNumber(context.getReadSequenceNumber());
             packetCipher.process(packet);
         } catch (CryptoException e) {
+            // Set compressedPayload if decryption failed to do so
             LOGGER.warn("Could not decrypt binary packet. Using {}", noneCipher, e);
             try {
                 noneCipher.process(packet);
             } catch (CryptoException ex) {
+                // FIXME Need to set compressedPayload to continue?
                 LOGGER.error("Could not decrypt with {}", noneCipher, ex);
             }
         }


### PR DESCRIPTION
<h1>Fixes missing plaintext initialization after Chachapoly AEAD fails.</h1>

The Chachapoly implementation throws a specific AEAD-exception. The caller **expects a generic crypto exception** to trigger the `none` cipher drop-in replacement initializes the `decryptedPayload` of the packet.

<h3>Two additional considerations:</h3>

- Alternatively, in the context of SSH-Attacker **it might be reasonable to ignore the bad MAC tag** in the Chachapoly implementation and decrypt regardless. Currently, throwing the AEAD exception conflicts with the use of plaintexts as `return` value. One of the mechanisms would need to change in order to decrypt despite bad tag.
- The error persists in the same way should the `none` cipher fail too, for some reason. Failing is implausible for the `none` cipher.

---

```diff
! If you don't care about the two additional considerations, merge without the lines including FIXME.
+ Or comment below to have me update the PR accordingly.
```

