### PR TITLE
feat: Implement ping@openssh.com extension

### DIFF
--- a/.idea/runConfigurations/Client___KEX_only__DH_.xml
+++ b/.idea/runConfigurations/Client___KEX_only__DH_.xml
@@ -8,7 +8,7 @@
     <method v="2">
       <option name="Maven.BeforeRunTask" enabled="true" file="$PROJECT_DIR$/pom.xml" goal="spotless:apply" />
       <option name="Make" enabled="true" />
-      <option name="RunConfigurationTask" enabled="true" run_configuration_name="OpenSSH 9.0 Server" run_configuration_type="docker-deploy" />
+      <option name="RunConfigurationTask" enabled="true" run_configuration_name="OpenSSH 9.5 Server" run_configuration_type="docker-deploy" />
     </method>
   </configuration>
 </component>

--- a/.idea/runConfigurations/Client___KEX_only__DH_GEX_.xml
+++ b/.idea/runConfigurations/Client___KEX_only__DH_GEX_.xml
@@ -8,7 +8,7 @@
     <method v="2">
       <option name="Maven.BeforeRunTask" enabled="true" file="$PROJECT_DIR$/pom.xml" goal="spotless:apply" />
       <option name="Make" enabled="true" />
-      <option name="RunConfigurationTask" enabled="true" run_configuration_name="OpenSSH 9.0 Server" run_configuration_type="docker-deploy" />
+      <option name="RunConfigurationTask" enabled="true" run_configuration_name="OpenSSH 9.5 Server" run_configuration_type="docker-deploy" />
     </method>
   </configuration>
 </component>

--- a/.idea/runConfigurations/Client___KEX_only__Dynamic_.xml
+++ b/.idea/runConfigurations/Client___KEX_only__Dynamic_.xml
@@ -8,7 +8,7 @@
     <method v="2">
       <option name="Maven.BeforeRunTask" enabled="true" file="$PROJECT_DIR$/pom.xml" goal="spotless:apply" />
       <option name="Make" enabled="true" />
-      <option name="RunConfigurationTask" enabled="true" run_configuration_name="OpenSSH 9.0 Server" run_configuration_type="docker-deploy" />
+      <option name="RunConfigurationTask" enabled="true" run_configuration_name="OpenSSH 9.5 Server" run_configuration_type="docker-deploy" />
     </method>
   </configuration>
 </component>

--- a/.idea/runConfigurations/Client___KEX_only__ECDH_.xml
+++ b/.idea/runConfigurations/Client___KEX_only__ECDH_.xml
@@ -8,7 +8,7 @@
     <method v="2">
       <option name="Maven.BeforeRunTask" enabled="true" file="$PROJECT_DIR$/pom.xml" goal="spotless:apply" />
       <option name="Make" enabled="true" />
-      <option name="RunConfigurationTask" enabled="true" run_configuration_name="OpenSSH 9.0 Server" run_configuration_type="docker-deploy" />
+      <option name="RunConfigurationTask" enabled="true" run_configuration_name="OpenSSH 9.5 Server" run_configuration_type="docker-deploy" />
     </method>
   </configuration>
 </component>

--- a/.idea/runConfigurations/Client___KEX_only__RSA_.xml
+++ b/.idea/runConfigurations/Client___KEX_only__RSA_.xml
@@ -8,7 +8,7 @@
     <method v="2">
       <option name="Maven.BeforeRunTask" enabled="true" file="$PROJECT_DIR$/pom.xml" goal="spotless:apply" />
       <option name="Make" enabled="true" />
-      <option name="RunConfigurationTask" enabled="true" run_configuration_name="OpenSSH 9.0 Server" run_configuration_type="docker-deploy" />
+      <option name="RunConfigurationTask" enabled="true" run_configuration_name="OpenSSH 9.5 Server" run_configuration_type="docker-deploy" />
     </method>
   </configuration>
 </component>

--- a/.idea/runConfigurations/OpenSSH_9_5_Client.xml
+++ b/.idea/runConfigurations/OpenSSH_9_5_Client.xml
@@ -1,8 +1,8 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="OpenSSH 9.0 Client" type="docker-deploy" factoryName="docker-image" server-name="Docker">
+  <configuration default="false" name="OpenSSH 9.5 Client" type="docker-deploy" factoryName="docker-image" server-name="Docker">
     <deployment type="docker-image">
       <settings>
-        <option name="imageTag" value="rub-nds/openssh-client:9.0p1" />
+        <option name="imageTag" value="rub-nds/openssh-client:9.5p1" />
         <option name="command" value="-v -u sshattacker -p 22510 -o StrictHostKeyChecking=no host.docker.internal" />
         <option name="containerName" value="intellij-openssh-client" />
       </settings>

--- a/.idea/runConfigurations/OpenSSH_9_5_Server.xml
+++ b/.idea/runConfigurations/OpenSSH_9_5_Server.xml
@@ -1,9 +1,8 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="OpenSSH 9.0 Server" type="docker-deploy" factoryName="docker-image" activateToolWindowBeforeRun="false" server-name="Docker">
+  <configuration default="false" name="OpenSSH 9.5 Server" type="docker-deploy" factoryName="docker-image" activateToolWindowBeforeRun="false" server-name="Docker">
     <deployment type="docker-image">
       <settings>
-        <option name="imageTag" value="rub-nds/openssh-server:9.0p1" />
-        <option name="command" value="" />
+        <option name="imageTag" value="rub-nds/openssh-server:9.5p1" />
         <option name="containerName" value="intellij-openssh-server" />
         <option name="portBindings">
           <list>

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/Extension.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/Extension.java
@@ -24,6 +24,7 @@ public enum Extension {
     EXT_AUTH_INFO("ext-auth-info"),
     GLOBAL_REQUESTS_OK("global-requests-ok"),
     PUBLICKEY_HOSTBOUND_OPENSSH_COM("publickey-hostbound@openssh.com"),
+    PING_OPENSSH_COM("ping@openssh.com"),
     UNKNOWN(null);
 
     private final String name;

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/MessageIdConstant.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/constants/MessageIdConstant.java
@@ -136,6 +136,8 @@ public enum MessageIdConstant {
     // 101 - 127 unassigned (channel related messages)
     // 128 - 191 reserved (for client protocols)
     // 192 - 255 reserved for private use (local extensions)
+    SSH_MSG_PING((byte) 192),
+    SSH_MSG_PONG((byte) 193),
     UNKNOWN((byte) 255);
 
     private final byte id;

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/common/ProtocolMessageParser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/common/ProtocolMessageParser.java
@@ -120,6 +120,10 @@ public abstract class ProtocolMessageParser<T extends ProtocolMessage<T>> extend
                     return new ExtensionInfoMessageParser(raw).parse();
                 case SSH_MSG_NEWCOMPRESS:
                     return new NewCompressMessageParser(raw).parse();
+                case SSH_MSG_PING:
+                    return new PingMessageParser(raw).parse();
+                case SSH_MSG_PONG:
+                    return new PongMessageParser(raw).parse();
                 case SSH_MSG_SERVICE_REQUEST:
                     return new ServiceRequestMessageParser(raw).parse();
                 case SSH_MSG_SERVICE_ACCEPT:

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/handler/PingMessageHandler.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/handler/PingMessageHandler.java
@@ -1,0 +1,57 @@
+/*
+ * SSH-Attacker - A Modular Penetration Testing Framework for SSH
+ *
+ * Copyright 2014-2023 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ *
+ * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
+ */
+package de.rub.nds.sshattacker.core.protocol.transport.handler;
+
+import de.rub.nds.sshattacker.core.protocol.common.SshMessageHandler;
+import de.rub.nds.sshattacker.core.protocol.transport.message.PingMessage;
+import de.rub.nds.sshattacker.core.protocol.transport.parser.PingMessageParser;
+import de.rub.nds.sshattacker.core.protocol.transport.preparator.PingMessagePreparator;
+import de.rub.nds.sshattacker.core.protocol.transport.serializer.PingMessageSerializer;
+import de.rub.nds.sshattacker.core.state.SshContext;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class PingMessageHandler extends SshMessageHandler<PingMessage> {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    public PingMessageHandler(SshContext context) {
+        super(context);
+    }
+
+    public PingMessageHandler(SshContext context, PingMessage message) {
+        super(context, message);
+    }
+
+    @Override
+    public void adjustContext() {
+        LOGGER.debug(
+                "PingMessage received from remote, data to respond length: {}",
+                message.getDataLength().getValue());
+    }
+
+    @Override
+    public PingMessageParser getParser(byte[] array) {
+        return new PingMessageParser(array);
+    }
+
+    @Override
+    public PingMessageParser getParser(byte[] array, int startPosition) {
+        return new PingMessageParser(array, startPosition);
+    }
+
+    @Override
+    public PingMessagePreparator getPreparator() {
+        return new PingMessagePreparator(context.getChooser(), message);
+    }
+
+    @Override
+    public PingMessageSerializer getSerializer() {
+        return new PingMessageSerializer(message);
+    }
+}

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/handler/PongMessageHandler.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/handler/PongMessageHandler.java
@@ -1,0 +1,57 @@
+/*
+ * SSH-Attacker - A Modular Penetration Testing Framework for SSH
+ *
+ * Copyright 2014-2023 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ *
+ * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
+ */
+package de.rub.nds.sshattacker.core.protocol.transport.handler;
+
+import de.rub.nds.sshattacker.core.protocol.common.SshMessageHandler;
+import de.rub.nds.sshattacker.core.protocol.transport.message.PongMessage;
+import de.rub.nds.sshattacker.core.protocol.transport.parser.PongMessageParser;
+import de.rub.nds.sshattacker.core.protocol.transport.preparator.PongMessagePreparator;
+import de.rub.nds.sshattacker.core.protocol.transport.serializer.PongMessageSerializer;
+import de.rub.nds.sshattacker.core.state.SshContext;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class PongMessageHandler extends SshMessageHandler<PongMessage> {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    public PongMessageHandler(SshContext context) {
+        super(context);
+    }
+
+    public PongMessageHandler(SshContext context, PongMessage message) {
+        super(context, message);
+    }
+
+    @Override
+    public void adjustContext() {
+        LOGGER.debug(
+                "PongMessage received from remote, responded data length: {}",
+                message.getDataLength().getValue());
+    }
+
+    @Override
+    public PongMessageParser getParser(byte[] array) {
+        return new PongMessageParser(array);
+    }
+
+    @Override
+    public PongMessageParser getParser(byte[] array, int startPosition) {
+        return new PongMessageParser(array, startPosition);
+    }
+
+    @Override
+    public PongMessagePreparator getPreparator() {
+        return new PongMessagePreparator(context.getChooser(), message);
+    }
+
+    @Override
+    public PongMessageSerializer getSerializer() {
+        return new PongMessageSerializer(message);
+    }
+}

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/handler/extension/PingExtensionHandler.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/handler/extension/PingExtensionHandler.java
@@ -1,0 +1,55 @@
+/*
+ * SSH-Attacker - A Modular Penetration Testing Framework for SSH
+ *
+ * Copyright 2014-2023 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ *
+ * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
+ */
+package de.rub.nds.sshattacker.core.protocol.transport.handler.extension;
+
+import de.rub.nds.sshattacker.core.protocol.transport.message.extension.PingExtension;
+import de.rub.nds.sshattacker.core.protocol.transport.parser.extension.PingExtensionParser;
+import de.rub.nds.sshattacker.core.protocol.transport.preparator.extension.PingExtensionPreparator;
+import de.rub.nds.sshattacker.core.protocol.transport.serializer.extension.PingExtensionSerializer;
+import de.rub.nds.sshattacker.core.state.SshContext;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class PingExtensionHandler extends AbstractExtensionHandler<PingExtension> {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    public PingExtensionHandler(SshContext context) {
+        super(context);
+    }
+
+    public PingExtensionHandler(SshContext context, PingExtension extension) {
+        super(context, extension);
+    }
+
+    @Override
+    public void adjustContext() {
+        LOGGER.info(
+                "Remote peer signaled support for ping@openssh.com extension via SSH_MSG_EXT_INFO");
+    }
+
+    @Override
+    public PingExtensionParser getParser(byte[] array) {
+        return new PingExtensionParser(array);
+    }
+
+    @Override
+    public PingExtensionParser getParser(byte[] array, int startPosition) {
+        return new PingExtensionParser(array, startPosition);
+    }
+
+    @Override
+    public PingExtensionPreparator getPreparator() {
+        return new PingExtensionPreparator(context.getChooser(), extension);
+    }
+
+    @Override
+    public PingExtensionSerializer getSerializer() {
+        return new PingExtensionSerializer(extension);
+    }
+}

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/message/ExtensionInfoMessage.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/message/ExtensionInfoMessage.java
@@ -13,10 +13,7 @@ import de.rub.nds.modifiablevariable.integer.ModifiableInteger;
 import de.rub.nds.sshattacker.core.protocol.common.ModifiableVariableHolder;
 import de.rub.nds.sshattacker.core.protocol.common.SshMessage;
 import de.rub.nds.sshattacker.core.protocol.transport.handler.ExtensionInfoMessageHandler;
-import de.rub.nds.sshattacker.core.protocol.transport.message.extension.AbstractExtension;
-import de.rub.nds.sshattacker.core.protocol.transport.message.extension.DelayCompressionExtension;
-import de.rub.nds.sshattacker.core.protocol.transport.message.extension.ServerSigAlgsExtension;
-import de.rub.nds.sshattacker.core.protocol.transport.message.extension.UnknownExtension;
+import de.rub.nds.sshattacker.core.protocol.transport.message.extension.*;
 import de.rub.nds.sshattacker.core.state.SshContext;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlElementWrapper;
@@ -33,6 +30,7 @@ public class ExtensionInfoMessage extends SshMessage<ExtensionInfoMessage> {
     @XmlElements({
         @XmlElement(type = ServerSigAlgsExtension.class, name = "ServerSigAlgsExtension"),
         @XmlElement(type = DelayCompressionExtension.class, name = "DelayCompressionExtension"),
+        @XmlElement(type = PingExtension.class, name = "PingExtension"),
         @XmlElement(type = UnknownExtension.class, name = "UnknownExtension")
     })
     private List<AbstractExtension<?>> extensions = new ArrayList<>();

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/message/PingMessage.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/message/PingMessage.java
@@ -1,0 +1,64 @@
+/*
+ * SSH-Attacker - A Modular Penetration Testing Framework for SSH
+ *
+ * Copyright 2014-2023 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ *
+ * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
+ */
+package de.rub.nds.sshattacker.core.protocol.transport.message;
+
+import de.rub.nds.modifiablevariable.ModifiableVariableFactory;
+import de.rub.nds.modifiablevariable.bytearray.ModifiableByteArray;
+import de.rub.nds.modifiablevariable.integer.ModifiableInteger;
+import de.rub.nds.sshattacker.core.protocol.common.SshMessage;
+import de.rub.nds.sshattacker.core.protocol.transport.handler.PingMessageHandler;
+import de.rub.nds.sshattacker.core.state.SshContext;
+
+public class PingMessage extends SshMessage<PingMessage> {
+
+    private ModifiableInteger dataLength;
+    private ModifiableByteArray data;
+
+    public ModifiableInteger getDataLength() {
+        return dataLength;
+    }
+
+    public void setDataLength(ModifiableInteger dataLength) {
+        this.dataLength = dataLength;
+    }
+
+    public void setDataLength(int dataLength) {
+        this.dataLength = ModifiableVariableFactory.safelySetValue(this.dataLength, dataLength);
+    }
+
+    public ModifiableByteArray getData() {
+        return data;
+    }
+
+    public void setData(ModifiableByteArray data) {
+        setData(data, false);
+    }
+
+    public void setData(ModifiableByteArray data, boolean adjustLengthField) {
+        if (adjustLengthField) {
+            setDataLength(data.getValue().length);
+        }
+        this.data = data;
+    }
+
+    public void setData(byte[] data) {
+        setData(data, false);
+    }
+
+    public void setData(byte[] data, boolean adjustLengthField) {
+        if (adjustLengthField) {
+            setDataLength(data.length);
+        }
+        this.data = ModifiableVariableFactory.safelySetValue(this.data, data);
+    }
+
+    @Override
+    public PingMessageHandler getHandler(SshContext context) {
+        return new PingMessageHandler(context, this);
+    }
+}

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/message/PongMessage.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/message/PongMessage.java
@@ -1,0 +1,64 @@
+/*
+ * SSH-Attacker - A Modular Penetration Testing Framework for SSH
+ *
+ * Copyright 2014-2023 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ *
+ * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
+ */
+package de.rub.nds.sshattacker.core.protocol.transport.message;
+
+import de.rub.nds.modifiablevariable.ModifiableVariableFactory;
+import de.rub.nds.modifiablevariable.bytearray.ModifiableByteArray;
+import de.rub.nds.modifiablevariable.integer.ModifiableInteger;
+import de.rub.nds.sshattacker.core.protocol.common.SshMessage;
+import de.rub.nds.sshattacker.core.protocol.transport.handler.PongMessageHandler;
+import de.rub.nds.sshattacker.core.state.SshContext;
+
+public class PongMessage extends SshMessage<PongMessage> {
+
+    private ModifiableInteger dataLength;
+    private ModifiableByteArray data;
+
+    public ModifiableInteger getDataLength() {
+        return dataLength;
+    }
+
+    public void setDataLength(ModifiableInteger dataLength) {
+        this.dataLength = dataLength;
+    }
+
+    public void setDataLength(int dataLength) {
+        this.dataLength = ModifiableVariableFactory.safelySetValue(this.dataLength, dataLength);
+    }
+
+    public ModifiableByteArray getData() {
+        return data;
+    }
+
+    public void setData(ModifiableByteArray data) {
+        setData(data, false);
+    }
+
+    public void setData(ModifiableByteArray data, boolean adjustLengthField) {
+        if (adjustLengthField) {
+            setDataLength(data.getValue().length);
+        }
+        this.data = data;
+    }
+
+    public void setData(byte[] data) {
+        setData(data, false);
+    }
+
+    public void setData(byte[] data, boolean adjustLengthField) {
+        if (adjustLengthField) {
+            setDataLength(data.length);
+        }
+        this.data = ModifiableVariableFactory.safelySetValue(this.data, data);
+    }
+
+    @Override
+    public PongMessageHandler getHandler(SshContext context) {
+        return new PongMessageHandler(context, this);
+    }
+}

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/message/extension/PingExtension.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/message/extension/PingExtension.java
@@ -1,0 +1,65 @@
+/*
+ * SSH-Attacker - A Modular Penetration Testing Framework for SSH
+ *
+ * Copyright 2014-2023 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ *
+ * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
+ */
+package de.rub.nds.sshattacker.core.protocol.transport.message.extension;
+
+import de.rub.nds.modifiablevariable.ModifiableVariableFactory;
+import de.rub.nds.modifiablevariable.integer.ModifiableInteger;
+import de.rub.nds.modifiablevariable.string.ModifiableString;
+import de.rub.nds.sshattacker.core.protocol.transport.handler.extension.PingExtensionHandler;
+import de.rub.nds.sshattacker.core.state.SshContext;
+import java.nio.charset.StandardCharsets;
+
+public class PingExtension extends AbstractExtension<PingExtension> {
+
+    private ModifiableInteger versionLength;
+    private ModifiableString version;
+
+    public ModifiableInteger getVersionLength() {
+        return versionLength;
+    }
+
+    public void setVersionLength(ModifiableInteger versionLength) {
+        this.versionLength = versionLength;
+    }
+
+    public void setVersionLength(int versionLength) {
+        this.versionLength =
+                ModifiableVariableFactory.safelySetValue(this.versionLength, versionLength);
+    }
+
+    public ModifiableString getVersion() {
+        return version;
+    }
+
+    public void setVersion(ModifiableString version) {
+        setVersion(version, false);
+    }
+
+    public void setVersion(ModifiableString version, boolean adjustLengthField) {
+        if (adjustLengthField) {
+            setVersionLength(version.getValue().getBytes(StandardCharsets.US_ASCII).length);
+        }
+        this.version = version;
+    }
+
+    public void setVersion(String version) {
+        setVersion(version, false);
+    }
+
+    public void setVersion(String version, boolean adjustLengthField) {
+        if (adjustLengthField) {
+            setVersionLength(version.getBytes(StandardCharsets.US_ASCII).length);
+        }
+        this.version = ModifiableVariableFactory.safelySetValue(this.version, version);
+    }
+
+    @Override
+    public PingExtensionHandler getHandler(SshContext context) {
+        return new PingExtensionHandler(context, this);
+    }
+}

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/parser/ExtensionInfoMessageParser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/parser/ExtensionInfoMessageParser.java
@@ -11,10 +11,7 @@ import de.rub.nds.sshattacker.core.constants.DataFormatConstants;
 import de.rub.nds.sshattacker.core.constants.Extension;
 import de.rub.nds.sshattacker.core.protocol.common.SshMessageParser;
 import de.rub.nds.sshattacker.core.protocol.transport.message.ExtensionInfoMessage;
-import de.rub.nds.sshattacker.core.protocol.transport.parser.extension.AbstractExtensionParser;
-import de.rub.nds.sshattacker.core.protocol.transport.parser.extension.DelayCompressionExtensionParser;
-import de.rub.nds.sshattacker.core.protocol.transport.parser.extension.ServerSigAlgsExtensionParser;
-import de.rub.nds.sshattacker.core.protocol.transport.parser.extension.UnknownExtensionParser;
+import de.rub.nds.sshattacker.core.protocol.transport.parser.extension.*;
 import java.nio.charset.StandardCharsets;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -59,6 +56,9 @@ public class ExtensionInfoMessageParser extends SshMessageParser<ExtensionInfoMe
                 case DELAY_COMPRESSION:
                     extensionParser =
                             new DelayCompressionExtensionParser(getArray(), extensionStartPointer);
+                    break;
+                case PING_OPENSSH_COM:
+                    extensionParser = new PingExtensionParser(getArray(), extensionStartPointer);
                     break;
                 default:
                     LOGGER.debug(

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/parser/PingMessageParser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/parser/PingMessageParser.java
@@ -1,0 +1,41 @@
+/*
+ * SSH-Attacker - A Modular Penetration Testing Framework for SSH
+ *
+ * Copyright 2014-2023 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ *
+ * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
+ */
+package de.rub.nds.sshattacker.core.protocol.transport.parser;
+
+import de.rub.nds.modifiablevariable.util.ArrayConverter;
+import de.rub.nds.sshattacker.core.constants.DataFormatConstants;
+import de.rub.nds.sshattacker.core.protocol.common.SshMessageParser;
+import de.rub.nds.sshattacker.core.protocol.transport.message.PingMessage;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class PingMessageParser extends SshMessageParser<PingMessage> {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    public PingMessageParser(byte[] array) {
+        super(array);
+    }
+
+    public PingMessageParser(byte[] array, int startPosition) {
+        super(array, startPosition);
+    }
+
+    @Override
+    protected PingMessage createMessage() {
+        return new PingMessage();
+    }
+
+    @Override
+    protected void parseMessageSpecificContents() {
+        message.setDataLength(parseIntField(DataFormatConstants.STRING_SIZE_LENGTH));
+        LOGGER.debug("Data length: {}", message.getDataLength().getValue());
+        message.setData(parseByteArrayField(message.getDataLength().getValue()));
+        LOGGER.debug("Data: {}", ArrayConverter.bytesToRawHexString(message.getData().getValue()));
+    }
+}

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/parser/PongMessageParser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/parser/PongMessageParser.java
@@ -1,0 +1,41 @@
+/*
+ * SSH-Attacker - A Modular Penetration Testing Framework for SSH
+ *
+ * Copyright 2014-2023 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ *
+ * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
+ */
+package de.rub.nds.sshattacker.core.protocol.transport.parser;
+
+import de.rub.nds.modifiablevariable.util.ArrayConverter;
+import de.rub.nds.sshattacker.core.constants.DataFormatConstants;
+import de.rub.nds.sshattacker.core.protocol.common.SshMessageParser;
+import de.rub.nds.sshattacker.core.protocol.transport.message.PongMessage;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class PongMessageParser extends SshMessageParser<PongMessage> {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    public PongMessageParser(byte[] array) {
+        super(array);
+    }
+
+    public PongMessageParser(byte[] array, int startPosition) {
+        super(array, startPosition);
+    }
+
+    @Override
+    protected PongMessage createMessage() {
+        return new PongMessage();
+    }
+
+    @Override
+    protected void parseMessageSpecificContents() {
+        message.setDataLength(parseIntField(DataFormatConstants.STRING_SIZE_LENGTH));
+        LOGGER.debug("Data length: {}", message.getDataLength().getValue());
+        message.setData(parseByteArrayField(message.getDataLength().getValue()));
+        LOGGER.debug("Data: {}", ArrayConverter.bytesToRawHexString(message.getData().getValue()));
+    }
+}

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/parser/extension/PingExtensionParser.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/parser/extension/PingExtensionParser.java
@@ -1,0 +1,47 @@
+/*
+ * SSH-Attacker - A Modular Penetration Testing Framework for SSH
+ *
+ * Copyright 2014-2023 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ *
+ * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
+ */
+package de.rub.nds.sshattacker.core.protocol.transport.parser.extension;
+
+import de.rub.nds.sshattacker.core.constants.DataFormatConstants;
+import de.rub.nds.sshattacker.core.protocol.transport.message.extension.PingExtension;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class PingExtensionParser extends AbstractExtensionParser<PingExtension> {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    public PingExtensionParser(byte[] array) {
+        super(array);
+    }
+
+    public PingExtensionParser(byte[] array, int startPosition) {
+        super(array, startPosition);
+    }
+
+    @Override
+    protected PingExtension createExtension() {
+        return new PingExtension();
+    }
+
+    @Override
+    protected void parseExtensionValue() {
+        parseVersionLength();
+        parseVersion();
+    }
+
+    private void parseVersionLength() {
+        extension.setVersionLength(parseIntField(DataFormatConstants.STRING_SIZE_LENGTH));
+        LOGGER.debug("Version length: {}", extension.getVersionLength().getValue());
+    }
+
+    private void parseVersion() {
+        extension.setVersion(parseByteString(extension.getVersionLength().getValue()));
+        LOGGER.debug("Version: {}", extension.getVersion().getValue());
+    }
+}

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/PingMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/PingMessagePreparator.java
@@ -1,0 +1,25 @@
+/*
+ * SSH-Attacker - A Modular Penetration Testing Framework for SSH
+ *
+ * Copyright 2014-2023 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ *
+ * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
+ */
+package de.rub.nds.sshattacker.core.protocol.transport.preparator;
+
+import de.rub.nds.sshattacker.core.constants.MessageIdConstant;
+import de.rub.nds.sshattacker.core.protocol.common.SshMessagePreparator;
+import de.rub.nds.sshattacker.core.protocol.transport.message.PingMessage;
+import de.rub.nds.sshattacker.core.workflow.chooser.Chooser;
+
+public class PingMessagePreparator extends SshMessagePreparator<PingMessage> {
+
+    public PingMessagePreparator(Chooser chooser, PingMessage message) {
+        super(chooser, message, MessageIdConstant.SSH_MSG_PING);
+    }
+
+    @Override
+    public void prepareMessageSpecificContents() {
+        getObject().setData(new byte[0], true);
+    }
+}

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/PongMessagePreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/PongMessagePreparator.java
@@ -1,0 +1,25 @@
+/*
+ * SSH-Attacker - A Modular Penetration Testing Framework for SSH
+ *
+ * Copyright 2014-2023 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ *
+ * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
+ */
+package de.rub.nds.sshattacker.core.protocol.transport.preparator;
+
+import de.rub.nds.sshattacker.core.constants.MessageIdConstant;
+import de.rub.nds.sshattacker.core.protocol.common.SshMessagePreparator;
+import de.rub.nds.sshattacker.core.protocol.transport.message.PongMessage;
+import de.rub.nds.sshattacker.core.workflow.chooser.Chooser;
+
+public class PongMessagePreparator extends SshMessagePreparator<PongMessage> {
+
+    public PongMessagePreparator(Chooser chooser, PongMessage message) {
+        super(chooser, message, MessageIdConstant.SSH_MSG_PONG);
+    }
+
+    @Override
+    public void prepareMessageSpecificContents() {
+        getObject().setData(new byte[0], true);
+    }
+}

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/extension/PingExtensionPreparator.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/preparator/extension/PingExtensionPreparator.java
@@ -1,0 +1,34 @@
+/*
+ * SSH-Attacker - A Modular Penetration Testing Framework for SSH
+ *
+ * Copyright 2014-2023 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ *
+ * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
+ */
+package de.rub.nds.sshattacker.core.protocol.transport.preparator.extension;
+
+import de.rub.nds.sshattacker.core.constants.Extension;
+import de.rub.nds.sshattacker.core.protocol.transport.message.extension.PingExtension;
+import de.rub.nds.sshattacker.core.workflow.chooser.Chooser;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class PingExtensionPreparator extends AbstractExtensionPreparator<PingExtension> {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    public PingExtensionPreparator(Chooser chooser, PingExtension extension) {
+        super(chooser, extension);
+    }
+
+    @Override
+    protected void prepareExtensionSpecificContents() {
+        // Sending ping@openssh.com is not allowed by the client according to OpenSSH specs
+        if (chooser.getContext().isClient()) {
+            LOGGER.warn(
+                    "Client prepared PingExtension which is supposed to be sent by the server only!");
+        }
+        getObject().setName(Extension.PING_OPENSSH_COM.getName(), true);
+        getObject().setVersion("0", true);
+    }
+}

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/PingMessageSerializer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/PingMessageSerializer.java
@@ -1,0 +1,32 @@
+/*
+ * SSH-Attacker - A Modular Penetration Testing Framework for SSH
+ *
+ * Copyright 2014-2023 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ *
+ * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
+ */
+package de.rub.nds.sshattacker.core.protocol.transport.serializer;
+
+import de.rub.nds.modifiablevariable.util.ArrayConverter;
+import de.rub.nds.sshattacker.core.constants.DataFormatConstants;
+import de.rub.nds.sshattacker.core.protocol.common.SshMessageSerializer;
+import de.rub.nds.sshattacker.core.protocol.transport.message.PingMessage;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class PingMessageSerializer extends SshMessageSerializer<PingMessage> {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    public PingMessageSerializer(PingMessage message) {
+        super(message);
+    }
+
+    @Override
+    public void serializeMessageSpecificContents() {
+        LOGGER.debug("Data length: {}", message.getDataLength().getValue());
+        appendInt(message.getDataLength().getValue(), DataFormatConstants.STRING_SIZE_LENGTH);
+        LOGGER.debug("Data: {}", ArrayConverter.bytesToRawHexString(message.getData().getValue()));
+        appendBytes(message.getData().getValue());
+    }
+}

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/PongMessageSerializer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/PongMessageSerializer.java
@@ -1,0 +1,32 @@
+/*
+ * SSH-Attacker - A Modular Penetration Testing Framework for SSH
+ *
+ * Copyright 2014-2023 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ *
+ * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
+ */
+package de.rub.nds.sshattacker.core.protocol.transport.serializer;
+
+import de.rub.nds.modifiablevariable.util.ArrayConverter;
+import de.rub.nds.sshattacker.core.constants.DataFormatConstants;
+import de.rub.nds.sshattacker.core.protocol.common.SshMessageSerializer;
+import de.rub.nds.sshattacker.core.protocol.transport.message.PongMessage;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class PongMessageSerializer extends SshMessageSerializer<PongMessage> {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    public PongMessageSerializer(PongMessage message) {
+        super(message);
+    }
+
+    @Override
+    public void serializeMessageSpecificContents() {
+        LOGGER.debug("Data length: {}", message.getDataLength().getValue());
+        appendInt(message.getDataLength().getValue(), DataFormatConstants.STRING_SIZE_LENGTH);
+        LOGGER.debug("Data: {}", ArrayConverter.bytesToRawHexString(message.getData().getValue()));
+        appendBytes(message.getData().getValue());
+    }
+}

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/extension/PingExtensionSerializer.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/protocol/transport/serializer/extension/PingExtensionSerializer.java
@@ -1,0 +1,39 @@
+/*
+ * SSH-Attacker - A Modular Penetration Testing Framework for SSH
+ *
+ * Copyright 2014-2023 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ *
+ * Licensed under Apache License 2.0 http://www.apache.org/licenses/LICENSE-2.0
+ */
+package de.rub.nds.sshattacker.core.protocol.transport.serializer.extension;
+
+import de.rub.nds.sshattacker.core.constants.DataFormatConstants;
+import de.rub.nds.sshattacker.core.protocol.transport.message.extension.PingExtension;
+import java.nio.charset.StandardCharsets;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class PingExtensionSerializer extends AbstractExtensionSerializer<PingExtension> {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    public PingExtensionSerializer(PingExtension extension) {
+        super(extension);
+    }
+
+    @Override
+    protected void serializeExtensionValue() {
+        serializeVersionLength();
+        serializeVersion();
+    }
+
+    private void serializeVersionLength() {
+        LOGGER.debug("Version length: {}", extension.getVersionLength().getValue());
+        appendInt(extension.getVersionLength().getValue(), DataFormatConstants.STRING_SIZE_LENGTH);
+    }
+
+    private void serializeVersion() {
+        LOGGER.debug("Version: {}", extension.getVersion().getValue());
+        appendString(extension.getVersion().getValue(), StandardCharsets.US_ASCII);
+    }
+}

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/action/MessageAction.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/action/MessageAction.java
@@ -109,6 +109,8 @@ public abstract class MessageAction extends ConnectionBoundAction {
         @XmlElement(type = KeyExchangeInitMessage.class, name = "KeyExchangeInit"),
         @XmlElement(type = NewCompressMessage.class, name = "NewCompress"),
         @XmlElement(type = NewKeysMessage.class, name = "NewKeys"),
+        @XmlElement(type = PingMessage.class, name = "Ping"),
+        @XmlElement(type = PongMessage.class, name = "Pong"),
         @XmlElement(type = RsaKeyExchangeDoneMessage.class, name = "RsaKeyExchangeDone"),
         @XmlElement(type = RsaKeyExchangePubkeyMessage.class, name = "RsaKeyExchangePubkey"),
         @XmlElement(type = RsaKeyExchangeSecretMessage.class, name = "RsaKeyExchangeSecret"),

--- a/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/action/ReceiveAction.java
+++ b/SSH-Core/src/main/java/de/rub/nds/sshattacker/core/workflow/action/ReceiveAction.java
@@ -118,6 +118,8 @@ public class ReceiveAction extends MessageAction implements ReceivingAction {
         @XmlElement(type = KeyExchangeInitMessage.class, name = "KeyExchangeInit"),
         @XmlElement(type = NewCompressMessage.class, name = "NewCompress"),
         @XmlElement(type = NewKeysMessage.class, name = "NewKeys"),
+        @XmlElement(type = PingMessage.class, name = "Ping"),
+        @XmlElement(type = PongMessage.class, name = "Pong"),
         @XmlElement(type = RsaKeyExchangeDoneMessage.class, name = "RsaKeyExchangeDone"),
         @XmlElement(type = RsaKeyExchangePubkeyMessage.class, name = "RsaKeyExchangePubkey"),
         @XmlElement(type = RsaKeyExchangeSecretMessage.class, name = "RsaKeyExchangeSecret"),


### PR DESCRIPTION
Implements the ping@openssh.com extension as introduced in OpenSSH 9.5p1. Specified in https://cvsweb.openbsd.org/cgi-bin/cvsweb/src/usr.bin/ssh/PROTOCOL#rev1.49.