### PR TITLE
ci: Replace deprecated coverage plugin

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -111,7 +111,10 @@ pipeline {
                     junit testResults: '**/target/failsafe-reports/TEST-*.xml', allowEmptyResults: true
                 }
                 success {
-                    publishCoverage adapters: [jacoco(mergeToOneReport: true, path: '**/target/site/jacoco/jacoco.xml')]
+                    discoverReferenceBuild()
+                    recordCoverage(tools: [[ parser: 'JACOCO' ]],
+                            id: 'jacoco', name: 'JaCoCo Coverage',
+                            sourceCodeRetention: 'LAST_BUILD')
                 }
             }
         }


### PR DESCRIPTION
- Update Maven used by Jenkins to 3.9.9
- Replace deprecated publishCoverage plugin by recordCoverage